### PR TITLE
Allocation Stamps:

### DIFF
--- a/ISOv4Plugin/ExtensionMethods/XmlExtensions.cs
+++ b/ISOv4Plugin/ExtensionMethods/XmlExtensions.cs
@@ -104,6 +104,33 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ExtensionMethods
             }
         }
 
+        public static uint? GetXmlNodeValueAsNullableUInt(this XmlNode xmlNode, string xPath)
+        {
+            string value = GetXmlNodeValue(xmlNode, xPath);
+            uint outValue;
+            if (UInt32.TryParse(value, out outValue))
+            {
+                return outValue;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        public static uint GetXmlNodeValueAsUInt(this XmlNode xmlNode, string xPath)
+        {
+            string value = GetXmlNodeValue(xmlNode, xPath);
+            uint outValue;
+            if (UInt32.TryParse(value, out outValue))
+            {
+                return outValue;
+            }
+            else
+            {
+                return 0;
+            }
+        }
 
         public static DateTime? GetXmlNodeValueAsNullableDateTime(this XmlNode xmlNode, string xPath)
         {

--- a/ISOv4Plugin/ISOModels/ISOAllocationStamp.cs
+++ b/ISOv4Plugin/ISOModels/ISOAllocationStamp.cs
@@ -20,7 +20,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ISOModels
         //Attributes
         public DateTime? Start { get; set; }  
         public DateTime? Stop { get; set; }
-        public long? Duration { get; set; }
+        public uint? Duration { get; set; } //Duration in XML is of unsignedLong type (Max 2^32-1 = 4,294,967,295). Found a possible typo in ISO 11783-10 Table D.2: "2^32-2" or is this correct so maximum value is 2 * int.MaxValue?
         public ISOAllocationStampType Type { get; set; }
 
         //Child Elements
@@ -32,7 +32,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ISOModels
             xmlBuilder.WriteStartElement("ASP");
             xmlBuilder.WriteXmlAttribute("A", Start.HasValue ? Start.Value.ToString("yyyy-MM-ddThh:mm:ss") : "");
             xmlBuilder.WriteXmlAttribute("B", Stop.HasValue ? Stop.Value.ToString("yyyy-MM-ddThh:mm:ss") : "");
-            xmlBuilder.WriteXmlAttribute<long>("C", Duration);
+            xmlBuilder.WriteXmlAttribute<uint>("C", Duration);
             xmlBuilder.WriteXmlAttribute("D", ((int)Type).ToString());
             foreach (ISOPosition item in Positions) { item.WriteXML(xmlBuilder); }
             xmlBuilder.WriteEndElement();
@@ -47,8 +47,10 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ISOModels
 
             ISOAllocationStamp item = new ISOAllocationStamp();
             item.Start = node.GetXmlNodeValueAsNullableDateTime("@A");
+            if (item.Start == null) //AllocationStamp XML element has to have a Start Attribute value defined
+                return null;
             item.Stop = node.GetXmlNodeValueAsNullableDateTime("@B");
-            item.Duration = node.GetXmlNodeValueAsNullableLong("@C");
+            item.Duration = node.GetXmlNodeValueAsNullableUInt("@C");
             item.Type = (ISOAllocationStampType)(node.GetXmlNodeValueAsInt("@D"));
 
             XmlNodeList ptnNodes = node.SelectNodes("PTN");

--- a/ISOv4Plugin/Mappers/AllocationStampMapper.cs
+++ b/ISOv4Plugin/Mappers/AllocationStampMapper.cs
@@ -90,7 +90,20 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
         {
             TimeScope adaptTimeScope = new TimeScope();
             adaptTimeScope.TimeStamp1 = isoAllocationStamp.Start;
-            adaptTimeScope.TimeStamp2 = isoAllocationStamp.Stop;
+
+            //[Check] AllocationStamp XML element: a recording with only the Start attribute defined is allowed
+            if (isoAllocationStamp.Stop != null)
+                adaptTimeScope.TimeStamp2 = isoAllocationStamp.Stop;
+            //[Check] AllocationStamp XML element: a recording with only the Start attribute defined is allowed
+            if (isoAllocationStamp.Duration != null)
+            {
+                if (isoAllocationStamp.Duration > int.MaxValue)
+                    adaptTimeScope.Duration = TimeSpan.FromSeconds((double)isoAllocationStamp.Duration);
+                else
+                    adaptTimeScope.Duration = new TimeSpan(0, 0, (int) isoAllocationStamp.Duration);
+            }
+                
+
             if (isoAllocationStamp.Positions.Count == 1)
             {
                 adaptTimeScope.Location1 = ImportPosition(isoAllocationStamp.Positions[0]);
@@ -107,9 +120,12 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
         private static Location ImportPosition(ISOPosition position)
         {
             Location location = new Location();
+            location.Position = new Point();
             location.Position.X = (double)position.PositionEast;
             location.Position.Y = (double)position.PositionNorth;
-            location.Position.Z = (double)position.PositionUp;
+            //[Check] if there is a PositionUp
+            if(position.PositionUp != null)
+                location.Position.Z = (double)position.PositionUp;
 
             if (position.HasNumberOfSatellites)
             {

--- a/ISOv4Plugin/Mappers/CommentAllocationMapper.cs
+++ b/ISOv4Plugin/Mappers/CommentAllocationMapper.cs
@@ -100,7 +100,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             Note adaptNote = new Note();
 
             //Allocation Stamps
-            if (isoCommentAllocation.AllocationStamp != null)
+            if (isoCommentAllocation.AllocationStamp != null && isoCommentAllocation.AllocationStamp.Start != null)
             {
                 adaptNote.TimeStamps = AllocationStampMapper.ImportAllocationStamps(new List<ISOAllocationStamp>() {isoCommentAllocation.AllocationStamp }).ToList();
             }


### PR DESCRIPTION
Allocation Stamps:
-Handling recordings with only the Start attribute defined
-Duration attribute has a max value of uint

Signed-off-by: Jason Roesbeke <jason.roesbeke@cnhind.com>