### PR TITLE
Not "short-circuiting" on a XML reader, ISO spec conditionals should be in the Mappers.

### DIFF
--- a/ISOv4Plugin/ISOModels/ISOAllocationStamp.cs
+++ b/ISOv4Plugin/ISOModels/ISOAllocationStamp.cs
@@ -47,8 +47,6 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ISOModels
 
             ISOAllocationStamp item = new ISOAllocationStamp();
             item.Start = node.GetXmlNodeValueAsNullableDateTime("@A");
-            if (item.Start == null) //AllocationStamp XML element has to have a Start Attribute value defined
-                return null;
             item.Stop = node.GetXmlNodeValueAsNullableDateTime("@B");
             item.Duration = node.GetXmlNodeValueAsNullableUInt("@C");
             item.Type = (ISOAllocationStampType)(node.GetXmlNodeValueAsInt("@D"));


### PR DESCRIPTION
Not "short-circuiting" on a XML reader such as returning null if ASP.Start is empty; such conditionals should be in the Mappers.  ISO specs live in the Mappers and the ISOModels only need to do the serializing and deserializing of the data. 
This could also allow to keep all IError implementations (reporting errors during mapping) regarding ISO specs inside the Mappers.

Made this change based on what was discussed at the ADAPT Technical Committee Meeting 13/12/2017.

Signed-off-by: Jason Roesbeke jason.roesbeke@cnhind.com