### PR TITLE
Setting Shapes on Guidance Patterns & Including Proprietary DDIs

### DIFF
--- a/ISOv4Plugin/ISOModels/ISO11783_TaskData.cs
+++ b/ISOv4Plugin/ISOModels/ISO11783_TaskData.cs
@@ -206,9 +206,12 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ISOModels
             {
                 XmlDocument linkDocument = new XmlDocument();
                 string linkPath = Path.Combine(baseFolder, linkListFile.FilenamewithExtension);
-                linkDocument.Load(linkPath);
-                XmlNode linkRoot = linkDocument.SelectSingleNode("ISO11783LinkList");
-                taskData.LinkList = ISO11783_LinkList.ReadXML(linkRoot, baseFolder);
+                if (File.Exists(linkPath))
+                {
+                    linkDocument.Load(linkPath);
+                    XmlNode linkRoot = linkDocument.SelectSingleNode("ISO11783LinkList");
+                    taskData.LinkList = ISO11783_LinkList.ReadXML(linkRoot, baseFolder);
+                }
             }
 
             return taskData;

--- a/ISOv4Plugin/Mappers/GuidancePatternMapper.cs
+++ b/ISOv4Plugin/Mappers/GuidancePatternMapper.cs
@@ -286,8 +286,8 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                     pivot.Center = pointMapper.ImportPoint(isoGuidancePattern.LineString.Points.First());
                     if (isoGuidancePattern.LineString.Points.Count == 3)
                     {
-                        pivot.StartPoint = pointMapper.ImportPoint(isoGuidancePattern.LineString.Points[2]);
-                        pivot.EndPoint = pointMapper.ImportPoint(isoGuidancePattern.LineString.Points[3]);
+                        pivot.StartPoint = pointMapper.ImportPoint(isoGuidancePattern.LineString.Points[1]);
+                        pivot.EndPoint = pointMapper.ImportPoint(isoGuidancePattern.LineString.Points[2]);
                     }
                     //Radius & GuidancePatternOptions not implemented in ADAPT
                     break;

--- a/ISOv4Plugin/Mappers/GuidancePatternMapper.cs
+++ b/ISOv4Plugin/Mappers/GuidancePatternMapper.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * ISO standards can be purchased through the ANSI webstore at https://webstore.ansi.org
 */
 
@@ -260,22 +260,41 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
         public GuidancePattern ImportGuidancePattern(ISOGuidancePattern isoGuidancePattern)
         {
             GuidancePattern pattern = null;
+            LineStringMapper lineStringMapper = new LineStringMapper(TaskDataMapper);
+            PointMapper pointMapper = new PointMapper(TaskDataMapper);
             switch (isoGuidancePattern.GuidancePatternType)
             {
                 case ISOGuidancePatternType.AB:
                     pattern = new AbLine();
+                    AbLine abLine = pattern as AbLine;
+                    abLine.A = pointMapper.ImportPoint(isoGuidancePattern.LineString.Points.First());
+                    abLine.B = pointMapper.ImportPoint(isoGuidancePattern.LineString.Points.Last());
                     break;
                 case ISOGuidancePatternType.APlus:
                     pattern = new APlus();
+                    APlus aPlus = pattern as APlus;
+                    aPlus.Point = pointMapper.ImportPoint(isoGuidancePattern.LineString.Points.First());
                     break;
                 case ISOGuidancePatternType.Curve:
                     pattern = new AbCurve();
+                    AbCurve abCurve = pattern as AbCurve;
+                    abCurve.Shape = new List<LineString>() { lineStringMapper.ImportLineString(isoGuidancePattern.LineString) }; //As with export, we only have 1 linestring.
                     break;
                 case ISOGuidancePatternType.Pivot:
                     pattern = new PivotGuidancePattern();
+                    PivotGuidancePattern pivot = pattern as PivotGuidancePattern;
+                    pivot.Center = pointMapper.ImportPoint(isoGuidancePattern.LineString.Points.First());
+                    if (isoGuidancePattern.LineString.Points.Count == 3)
+                    {
+                        pivot.StartPoint = pointMapper.ImportPoint(isoGuidancePattern.LineString.Points[2]);
+                        pivot.EndPoint = pointMapper.ImportPoint(isoGuidancePattern.LineString.Points[3]);
+                    }
+                    //Radius & GuidancePatternOptions not implemented in ADAPT
                     break;
                 case ISOGuidancePatternType.Spiral:
                     pattern = new Spiral();
+                    Spiral spiral = pattern as Spiral;
+                    spiral.Shape = lineStringMapper.ImportLineString(isoGuidancePattern.LineString);
                     break;
             }
 

--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/ActualLoadingSystemStatusMeterCreator.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/ActualLoadingSystemStatusMeterCreator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
@@ -41,7 +41,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             return meters;
         }
 
-        public EnumeratedValue GetValueForMeter(SpatialValue value, EnumeratedWorkingData meter)
+        public EnumeratedValue GetValueForMeter(SpatialValue value, ISOEnumeratedMeter meter)
         {
             if (Convert.ToInt32(value.DataLogValue.ProcessDataDDI, 16) != DDI)
                 return null;

--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/CondensedWorkStateMeterCreator.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/CondensedWorkStateMeterCreator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
@@ -119,7 +119,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             {
                 meters.Add(new ISOEnumeratedMeter
                 {
-                    //DeviceElementUseId = i,  //Set elsewhere
+                    SectionIndex = i,  
                     Representation = Representation,
                     GetEnumeratedValue = GetValueForMeter
                 });
@@ -128,9 +128,9 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             return meters;
         }
 
-        public EnumeratedValue GetValueForMeter(SpatialValue value, EnumeratedWorkingData meter)
+        public EnumeratedValue GetValueForMeter(SpatialValue value, ISOEnumeratedMeter meter)// EnumeratedWorkingData meter)
         {
-            var sectionValue = GetSectionValue((uint)value.Value, meter.DeviceElementUseId);
+            var sectionValue = GetSectionValue((uint)value.Value, meter.SectionIndex);
             var enumerationMember = SectionValueToEnumerationMember[(int)sectionValue];
 
             return new EnumeratedValue

--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/ConnectorTypeMeterCreator.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/ConnectorTypeMeterCreator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
@@ -31,7 +31,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             return new List<ISOEnumeratedMeter> { meter };
         }
 
-        public EnumeratedValue GetValueForMeter(SpatialValue value, EnumeratedWorkingData meter)
+        public EnumeratedValue GetValueForMeter(SpatialValue value, ISOEnumeratedMeter meter)
         {
             if (Convert.ToInt32(value.DataLogValue.ProcessDataDDI, 16) != DDI)
                 return null;

--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/IEnumeratedMeterCreator.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/IEnumeratedMeterCreator.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
 using AgGateway.ADAPT.ApplicationDataModel.Representations;
 using AgGateway.ADAPT.ISOv4Plugin.ObjectModel;
@@ -11,12 +11,13 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
         int DDI { get; set; }
         int StartingSection { get; }
         List<ISOEnumeratedMeter> CreateMeters(IEnumerable<ISOSpatialRow> spatialRows);  //CondensedWorkstateMeter is necessarily forcing CreateMeters process to read spatial data to create meters.
-        EnumeratedValue GetValueForMeter(SpatialValue value, EnumeratedWorkingData workingData);
+        EnumeratedValue GetValueForMeter(SpatialValue value, ISOEnumeratedMeter workingData);
         UInt32 GetMetersValue(List<WorkingData> meters, SpatialRecord spatialRecord);
     }
 
     public class ISOEnumeratedMeter : EnumeratedWorkingData
     {
-        public Func<SpatialValue, ISOEnumeratedMeter, EnumeratedValue> GetEnumeratedValue { get; set;}   
+        public Func<SpatialValue, ISOEnumeratedMeter, EnumeratedValue> GetEnumeratedValue { get; set;}
+        public int SectionIndex { get; set; }
     }
 }

--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/NetWeightStateMeterCreator.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/NetWeightStateMeterCreator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
@@ -31,7 +31,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             return new List<ISOEnumeratedMeter> { meter };
         }
 
-        public EnumeratedValue GetValueForMeter(SpatialValue value, EnumeratedWorkingData meter)
+        public EnumeratedValue GetValueForMeter(SpatialValue value, ISOEnumeratedMeter meter)
         {
             if (Convert.ToInt32(value.DataLogValue.ProcessDataDDI, 16) != DDI)
                 return null;

--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/PrescriptionControlMeterCreator.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/PrescriptionControlMeterCreator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
@@ -32,7 +32,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             return new List<ISOEnumeratedMeter> { meter };
         }
 
-        public EnumeratedValue GetValueForMeter(SpatialValue value, EnumeratedWorkingData meter)
+        public EnumeratedValue GetValueForMeter(SpatialValue value, ISOEnumeratedMeter meter)
         {
             if (value == null)
                 return null;

--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/SectionControlStateMeterCreator.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/SectionControlStateMeterCreator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
@@ -31,7 +31,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             return new List<ISOEnumeratedMeter> { meter };
         }
 
-        public EnumeratedValue GetValueForMeter(SpatialValue value, EnumeratedWorkingData meter)
+        public EnumeratedValue GetValueForMeter(SpatialValue value, ISOEnumeratedMeter meter)
         {
             if (Convert.ToInt32(value.DataLogValue.ProcessDataDDI, 16) != DDI)
                 return null;

--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/SectionMapper.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/SectionMapper.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using AgGateway.ADAPT.ApplicationDataModel.Equipment;
 using AgGateway.ADAPT.ISOv4Plugin.ObjectModel;
@@ -56,18 +56,33 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                         //Read any spatially-listed widths/offsets on this data onto the DeviceElementConfiguration objects
                         hierarchy.SetWidthsAndOffsetsFromSpatialData(isoRecords, config, RepresentationMapper);
 
-                        //Create the DeviceElementUse
-                        deviceElementUse = new DeviceElementUse();
-                        deviceElementUse.Depth = depth;
-                        deviceElementUse.Order = order;
-                        deviceElementUse.OperationDataId = operationDataId;
-                        deviceElementUse.DeviceConfigurationId = config.Id.ReferenceId;
-
-                        //Add Working Data for any data on this device element
-                        List<WorkingData> data = _workingDataMapper.Map(time, isoRecords, deviceElementUse, hierarchy, sections);
-                        if (data.Any())
+                        deviceElementUse = sections.FirstOrDefault(d => d.DeviceConfigurationId == config.Id.ReferenceId);
+                        if (deviceElementUse == null)
                         {
-                            workingDatas.AddRange(data);
+                            //Create the DeviceElementUse
+                            deviceElementUse = new DeviceElementUse();
+                            deviceElementUse.Depth = depth;
+                            deviceElementUse.Order = order;
+                            deviceElementUse.OperationDataId = operationDataId;
+                            deviceElementUse.DeviceConfigurationId = config.Id.ReferenceId;
+
+                            //Add Working Data for any data on this device element
+                            List<WorkingData> data = _workingDataMapper.Map(time, isoRecords, deviceElementUse, hierarchy, sections);
+                            if (data.Any())
+                            {
+                                workingDatas.AddRange(data);
+                            }
+                        }
+                        else
+                        {
+                            workingDatas = deviceElementUse.GetWorkingDatas().ToList();
+
+                            //Add Additional Working Data
+                            List<WorkingData> data = _workingDataMapper.Map(time, isoRecords, deviceElementUse, hierarchy, sections);
+                            if (data.Any())
+                            {
+                                workingDatas.AddRange(data);
+                            }
                         }
 
                         deviceElementUse.GetWorkingDatas = () => workingDatas;

--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/SkyConditionsMeterCreator.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/SkyConditionsMeterCreator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
@@ -32,7 +32,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
         }
 
         
-        public EnumeratedValue GetValueForMeter(SpatialValue value, EnumeratedWorkingData meter)
+        public EnumeratedValue GetValueForMeter(SpatialValue value, ISOEnumeratedMeter meter)
         {
             if (value.DataLogValue.ProcessDataDDI.AsInt32DDI() != DDI)
                 return null;

--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/SpatialRecordMapper.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/SpatialRecordMapper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -85,6 +85,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
         private void SetNumericMeterValue(ISOSpatialRow isoSpatialRow, NumericWorkingData meter, SpatialRecord spatialRecord)
         {
             var isoValue = isoSpatialRow.SpatialValues.SingleOrDefault(v =>
+                                v.DataLogValue.ProcessDataDDI != "DFFE" &&
                                 v.DataLogValue.DeviceElementIdRef == _workingDataMapper.DataLogValuesByWorkingDataID[meter.Id.ReferenceId].DeviceElementIdRef && 
                                 v.DataLogValue.ProcessDataDDI == _workingDataMapper.DataLogValuesByWorkingDataID[meter.Id.ReferenceId].ProcessDataDDI);
 

--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/WorkStateMeterCreator.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/WorkStateMeterCreator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
@@ -31,7 +31,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             return new List<ISOEnumeratedMeter> {meter};
         }
 
-        public EnumeratedValue GetValueForMeter(SpatialValue value, EnumeratedWorkingData meter)
+        public EnumeratedValue GetValueForMeter(SpatialValue value, ISOEnumeratedMeter meter)
         {
             var enumMember = value != null && value.Value == 1
                 ? DefinedTypeEnumerationInstanceList.dtiRecordingStatusOn.ToModelEnumMember()


### PR DESCRIPTION
Guidance Pattern import was omitting the shape.   Adding for all patterns including a partial implementation for Pivots which are currently under discussion.

Proprietary DDIs were being suppressed.   Reporting out with a default unit of measure.