### PR TITLE
Setting file path into Catalog description

### DIFF
--- a/ISOv4Plugin/ISOModels/ISO11783_TaskData.cs
+++ b/ISOv4Plugin/ISOModels/ISO11783_TaskData.cs
@@ -23,6 +23,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ISOModels
 
         public List<ISOElement> ChildElements { get; set; }
         public ISO11783_LinkList LinkList { get; set; }
+        public string DataFolder { get; set; }
         public string FilePath { get; set; }
 
         public int VersionMajor { get; set;}

--- a/ISOv4Plugin/Mappers/TaskDataMapper.cs
+++ b/ISOv4Plugin/Mappers/TaskDataMapper.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * ISO standards can be purchased through the ANSI webstore at https://webstore.ansi.org
 */
 
@@ -262,7 +262,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             UniqueIDMapper = new UniqueIdMapper(ISOTaskData.LinkList);
 
             AdaptDataModel = new ApplicationDataModel.ADM.ApplicationDataModel();
-            AdaptDataModel.Catalog = new Catalog() { Description = "ISO TaskData" };
+            AdaptDataModel.Catalog = new Catalog() { Description = taskData.FilePath };
             AdaptDataModel.Documents = new Documents();
 
             //Comments 

--- a/ISOv4Plugin/Plugin.cs
+++ b/ISOv4Plugin/Plugin.cs
@@ -54,9 +54,8 @@ namespace AgGateway.ADAPT.ISOv4Plugin
             foreach (var taskData in taskDataObjects)
             {
                 //Convert the ISO model to ADAPT
-                TaskDataMapper taskDataMapper = new TaskDataMapper(taskData.FilePath, properties);
+                TaskDataMapper taskDataMapper = new TaskDataMapper(taskData.DataFolder, properties);
                 ApplicationDataModel.ADM.ApplicationDataModel dataModel = taskDataMapper.Import(taskData);
-
                 adms.Add(dataModel);
             }
 
@@ -119,14 +118,15 @@ namespace AgGateway.ADAPT.ISOv4Plugin
                 //Per ISO11783-10:2015(E) 8.5, all related files are in the same directory as the TASKDATA.xml file.
                 //The TASKDATA directory is only required when exporting to removable media.
                 //As such, the plugin will import data in any directory structure, and always export to a TASKDATA directory.
-                string filePath = Path.GetDirectoryName(taskDataFile);
+                string dataFolder = Path.GetDirectoryName(taskDataFile);
 
                 //Deserialize the ISOXML into the ISO models
                 XmlDocument document = new XmlDocument();
                 document.Load(taskDataFile);
                 XmlNode rootNode = document.SelectSingleNode("ISO11783_TaskData");
-                ISO11783_TaskData taskData = ISO11783_TaskData.ReadXML(rootNode, filePath);
-                taskData.FilePath = filePath;
+                ISO11783_TaskData taskData = ISO11783_TaskData.ReadXML(rootNode, dataFolder);
+                taskData.DataFolder = dataFolder;
+                taskData.FilePath = taskDataFile;
 
                 taskDataObjects.Add(taskData);
             }


### PR DESCRIPTION
Rather than just "ISO Task Data," the Catalog.description provides a spot to expose the file path to the data.   This is useful when the plugin reads multiple TaskData.xml files and generates more than one adm model. 