### PR TITLE
Additional Air Seeder/Multiple Product Fixes

### DIFF
--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/SectionMapper.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/SectionMapper.cs
@@ -12,7 +12,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
 {
     public interface ISectionMapper
     {
-        List<DeviceElementUse> Map(ISOTime time, IEnumerable<ISOSpatialRow> isoRecords, int operationDataId, IEnumerable<string> isoDeviceElementIDs);
+        List<DeviceElementUse> Map(ISOTime time, IEnumerable<ISOSpatialRow> isoRecords, int operationDataId, IEnumerable<string> isoDeviceElementIDs, Dictionary<string, List<ISOProductAllocation>> isoProductAllocations);
         List<DeviceElementUse> ConvertToBaseTypes(List<DeviceElementUse> meters);
     }
 
@@ -26,7 +26,11 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             _workingDataMapper = meterMapper;
         }
 
-        public List<DeviceElementUse> Map(ISOTime time, IEnumerable<ISOSpatialRow> isoRecords, int operationDataId, IEnumerable<string> isoDeviceElementIDs)
+        public List<DeviceElementUse> Map(ISOTime time,
+                                          IEnumerable<ISOSpatialRow> isoRecords,
+                                          int operationDataId,
+                                          IEnumerable<string> isoDeviceElementIDs,
+                                          Dictionary<string, List<ISOProductAllocation>> isoProductAllocations)
         {
             var sections = new List<DeviceElementUse>();
             foreach (string isoDeviceElementID in isoDeviceElementIDs)
@@ -67,7 +71,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                             deviceElementUse.DeviceConfigurationId = config.Id.ReferenceId;
 
                             //Add Working Data for any data on this device element
-                            List<WorkingData> data = _workingDataMapper.Map(time, isoRecords, deviceElementUse, hierarchy, sections);
+                            List<WorkingData> data = _workingDataMapper.Map(time, isoRecords, deviceElementUse, hierarchy, sections, isoProductAllocations);
                             if (data.Any())
                             {
                                 workingDatas.AddRange(data);
@@ -78,7 +82,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                             workingDatas = deviceElementUse.GetWorkingDatas().ToList();
 
                             //Add Additional Working Data
-                            List<WorkingData> data = _workingDataMapper.Map(time, isoRecords, deviceElementUse, hierarchy, sections);
+                            List<WorkingData> data = _workingDataMapper.Map(time, isoRecords, deviceElementUse, hierarchy, sections, isoProductAllocations);
                             if (data.Any())
                             {
                                 workingDatas.AddRange(data);

--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/SpatialRecordMapper.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/SpatialRecordMapper.cs
@@ -13,8 +13,8 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
 {
     public interface ISpatialRecordMapper
     {
-        IEnumerable<SpatialRecord> Map(IEnumerable<ISOSpatialRow> isoSpatialRows, List<WorkingData> meters);
-        SpatialRecord Map(ISOSpatialRow isoSpatialRow, List<WorkingData> meters);
+        IEnumerable<SpatialRecord> Map(IEnumerable<ISOSpatialRow> isoSpatialRows, List<WorkingData> meters, Dictionary<string, List<ISOProductAllocation>> productAllocations);
+        SpatialRecord Map(ISOSpatialRow isoSpatialRow, List<WorkingData> meters, Dictionary<string, List<ISOProductAllocation>> productAllocations);
     }
 
     public class SpatialRecordMapper : ISpatialRecordMapper
@@ -23,27 +23,29 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
         private readonly IRepresentationValueInterpolator _representationValueInterpolator;
         private readonly IWorkingDataMapper _workingDataMapper;
         private readonly ISectionMapper _sectionMapper;
+        private readonly TaskDataMapper _taskDataMapper;
 
-        public SpatialRecordMapper(IRepresentationValueInterpolator representationValueInterpolator, ISectionMapper sectionMapper, IWorkingDataMapper workingDataMapper)
+        public SpatialRecordMapper(IRepresentationValueInterpolator representationValueInterpolator, ISectionMapper sectionMapper, IWorkingDataMapper workingDataMapper, TaskDataMapper taskDataMapper)
         {
             _representationValueInterpolator = representationValueInterpolator;
             _workingDataMapper = workingDataMapper;
             _sectionMapper = sectionMapper;
+            _taskDataMapper = taskDataMapper;
         }
 
-        public IEnumerable<SpatialRecord> Map(IEnumerable<ISOSpatialRow> isoSpatialRows, List<WorkingData> meters)
+        public IEnumerable<SpatialRecord> Map(IEnumerable<ISOSpatialRow> isoSpatialRows, List<WorkingData> meters, Dictionary<string, List<ISOProductAllocation>> productAllocations)
         {
             _representationValueInterpolator.Clear();
-            return isoSpatialRows.Select(r => Map(r, meters));
+            return isoSpatialRows.Select(r => Map(r, meters, productAllocations));
         }
 
-        public SpatialRecord Map(ISOSpatialRow isoSpatialRow, List<WorkingData> meters)
+        public SpatialRecord Map(ISOSpatialRow isoSpatialRow, List<WorkingData> meters, Dictionary<string, List<ISOProductAllocation>> productAllocations)
         {
             var spatialRecord = new SpatialRecord();
 
             foreach (var meter in meters.OfType<NumericWorkingData>())
             {
-                SetNumericMeterValue(isoSpatialRow, meter, spatialRecord);
+                SetNumericMeterValue(isoSpatialRow, meter, spatialRecord, productAllocations);
             }
 
             foreach (var meter in meters.OfType<EnumeratedWorkingData>())
@@ -82,14 +84,15 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             }
         }
 
-        private void SetNumericMeterValue(ISOSpatialRow isoSpatialRow, NumericWorkingData meter, SpatialRecord spatialRecord)
+        private void SetNumericMeterValue(ISOSpatialRow isoSpatialRow, NumericWorkingData meter, SpatialRecord spatialRecord, Dictionary<string, List<ISOProductAllocation>> productAllocations)
         {
             var isoValue = isoSpatialRow.SpatialValues.SingleOrDefault(v =>
                                 v.DataLogValue.ProcessDataDDI != "DFFE" &&
+                                _workingDataMapper.DataLogValuesByWorkingDataID.ContainsKey(meter.Id.ReferenceId) &&
                                 v.DataLogValue.DeviceElementIdRef == _workingDataMapper.DataLogValuesByWorkingDataID[meter.Id.ReferenceId].DeviceElementIdRef && 
                                 v.DataLogValue.ProcessDataDDI == _workingDataMapper.DataLogValuesByWorkingDataID[meter.Id.ReferenceId].ProcessDataDDI);
 
-            
+
             if (isoValue != null)
             {
                 var value = new NumericRepresentationValue(meter.Representation as NumericRepresentation, meter.UnitOfMeasure, new NumericValue(meter.UnitOfMeasure, isoValue.Value));
@@ -97,6 +100,36 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
 
                 var other = new NumericRepresentationValue(meter.Representation as NumericRepresentation, meter.UnitOfMeasure, new NumericValue(meter.UnitOfMeasure, isoValue.Value));
                 _representationValueInterpolator.SetMostRecentMeterValue(meter, other);
+            }
+            else if (meter.Representation.Code == "vrProductIndex")
+            {
+                string detID = _workingDataMapper.ISODeviceElementIDsByWorkingDataID[meter.Id.ReferenceId];
+                if (productAllocations.ContainsKey(detID)) //The DeviceElement for this meter exists in the list of allocations
+                {
+                    double numericValue = 0d;
+                    if (productAllocations[detID].Count == 1 || TimeLogMapper.GetDistinctProductIDs(_taskDataMapper, productAllocations).Count == 1)
+                    {
+                        //This product is consistent throughout the task on this device element
+                        int? adaptProductID = _taskDataMapper.InstanceIDMap.GetADAPTID(productAllocations[detID].Single().ProductIdRef);
+                        numericValue = adaptProductID.HasValue ? adaptProductID.Value : 0d;
+
+                    }
+                    else if (productAllocations[detID].Count > 1)
+                    {
+                        //There are multiple product allocations for the device element
+                        //Find the product allocation that governs this timestamp
+                        ISOProductAllocation relevantPan = productAllocations[detID].FirstOrDefault(p => p.AllocationStamp.Start <= spatialRecord.Timestamp &&
+                                                                                                         (p.AllocationStamp.Stop == null ||
+                                                                                                          p.AllocationStamp.Stop >= spatialRecord.Timestamp));
+                        if (relevantPan != null)
+                        {
+                            int? adaptProductID = _taskDataMapper.InstanceIDMap.GetADAPTID(relevantPan.ProductIdRef);
+                            numericValue = adaptProductID.HasValue ? adaptProductID.Value : 0d;
+                        }
+                    }                    
+                    var value = new NumericRepresentationValue(meter.Representation as NumericRepresentation, meter.UnitOfMeasure, new NumericValue(meter.UnitOfMeasure, numericValue));
+                    spatialRecord.SetMeterValue(meter, value);
+                }
             }
             else
             {

--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/WorkingDataMapper.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/WorkingDataMapper.cs
@@ -160,8 +160,6 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                     WorkingData workingData = condensedWorkingDatas[i];
 
                     DeviceElementUse condensedDeviceElementUse = new DeviceElementUse();
-                    condensedDeviceElementUse.Depth = deviceElementUse.Depth + 1;
-                    condensedDeviceElementUse.Order = i + 1;
                     condensedDeviceElementUse.OperationDataId = deviceElementUse.OperationDataId;
 
                     ISODeviceElement targetSection = targetSections[i];
@@ -171,10 +169,19 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                         DeviceElement deviceElement = DataModel.Catalog.DeviceElements.SingleOrDefault(d => d.Id.ReferenceId == deviceElementID.Value);
                         if (deviceElement != null)
                         {
-                            DeviceElementConfiguration deviceElementConfig = DeviceElementMapper.GetDeviceElementConfiguration(deviceElement, isoDeviceElementHierarchy.FromDeviceElementID(targetSection.DeviceElementId), DataModel.Catalog);
+                            //Reference the device element in its hierarchy so that we can get the depth & order
+                            DeviceElementHierarchy deviceElementInHierarchy = isoDeviceElementHierarchy.FromDeviceElementID(targetSection.DeviceElementId);
+
+                            //Get the config id
+                            DeviceElementConfiguration deviceElementConfig = DeviceElementMapper.GetDeviceElementConfiguration(deviceElement, deviceElementInHierarchy, DataModel.Catalog);
                             condensedDeviceElementUse.DeviceConfigurationId = deviceElementConfig.Id.ReferenceId;
+
+                            //Set the depth & order
+                            condensedDeviceElementUse.Depth = deviceElementInHierarchy.Depth;
+                            condensedDeviceElementUse.Order = deviceElementInHierarchy.Order;
                         }
                     }
+
                     condensedDeviceElementUse.GetWorkingDatas = () => new List<WorkingData> { workingData };
 
                     workingData.DeviceElementUseId = condensedDeviceElementUse.Id.ReferenceId;

--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/WorkingDataMapper.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/WorkingDataMapper.cs
@@ -8,6 +8,8 @@ using AgGateway.ADAPT.ISOv4Plugin.Representation;
 using AgGateway.ADAPT.ApplicationDataModel.Equipment;
 using AgGateway.ADAPT.ISOv4Plugin.ExtensionMethods;
 using AgGateway.ADAPT.ApplicationDataModel.Representations;
+using AgGateway.ADAPT.Representation.RepresentationSystem;
+using AgGateway.ADAPT.Representation.UnitSystem;
 
 namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
 {
@@ -15,9 +17,10 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
 
     public interface IWorkingDataMapper
     {
-        List<WorkingData> Map(ISOTime time, IEnumerable<ISOSpatialRow> isoRecords, DeviceElementUse deviceElementUse, DeviceElementHierarchy isoDeviceElementHierarchy, List<DeviceElementUse> pendingDeviceElementUses);
+        List<WorkingData> Map(ISOTime time, IEnumerable<ISOSpatialRow> isoRecords, DeviceElementUse deviceElementUse, DeviceElementHierarchy isoDeviceElementHierarchy, List<DeviceElementUse> pendingDeviceElementUses, Dictionary<string, List<ISOProductAllocation>> isoProductAllocations);
         WorkingData ConvertToBaseType(WorkingData meter);
         Dictionary<int, ISODataLogValue> DataLogValuesByWorkingDataID { get; set; }
+        Dictionary<int, string> ISODeviceElementIDsByWorkingDataID { get; set; }
     }
 
     public class WorkingDataMapper : BaseMapper, IWorkingDataMapper
@@ -25,6 +28,8 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
         private readonly IEnumeratedMeterFactory _enumeratedMeterCreatorFactory;
         private readonly Dictionary<int, DdiDefinition> _ddis;
         public Dictionary<int, ISODataLogValue> DataLogValuesByWorkingDataID { get; set;}
+        public Dictionary<int, string> ISODeviceElementIDsByWorkingDataID { get; set; }
+
 
 
         public WorkingDataMapper(IEnumeratedMeterFactory enumeratedMeterCreatorFactory, TaskDataMapper taskDataMapper)
@@ -33,9 +38,15 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             _enumeratedMeterCreatorFactory = enumeratedMeterCreatorFactory;
             _ddis = DdiLoader.Ddis;
             DataLogValuesByWorkingDataID = new Dictionary<int, ISODataLogValue>();
+            ISODeviceElementIDsByWorkingDataID = new Dictionary<int, string>();
         }
 
-        public List<WorkingData> Map(ISOTime time, IEnumerable<ISOSpatialRow> isoSpatialRows, DeviceElementUse deviceElementUse, DeviceElementHierarchy isoDeviceElementHierarchy, List<DeviceElementUse> pendingDeviceElementUses)
+        public List<WorkingData> Map(ISOTime time,
+                                     IEnumerable<ISOSpatialRow> isoSpatialRows,
+                                     DeviceElementUse deviceElementUse,
+                                     DeviceElementHierarchy isoDeviceElementHierarchy,
+                                     List<DeviceElementUse> pendingDeviceElementUses,
+                                     Dictionary<string, List<ISOProductAllocation>> isoProductAllocations)
         {
             var workingDatas = new List<WorkingData>();
 
@@ -47,11 +58,26 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                 dlv.Order = order;
             }
 
+
+            //Create vrProductIndex on relevant device elements if more than one product on this OperationData
+            if (TimeLogMapper.GetDistinctProductIDs(TaskDataMapper, isoProductAllocations).Count > 1 &&
+                isoProductAllocations.Keys.Contains(isoDeviceElementHierarchy.DeviceElement.DeviceElementId))
+            {
+                WorkingData workingData = CreateProductIndexWorkingData(deviceElementUse.Id.ReferenceId);
+                ISODeviceElementIDsByWorkingDataID.Add(workingData.Id.ReferenceId, isoDeviceElementHierarchy.DeviceElement.DeviceElementId);
+                workingDatas.Add(workingData);
+            }
+
             //Add the Working Datas for this DeviceElement
             IEnumerable<ISODataLogValue> deviceElementDLVs = allDLVs.Where(dlv => dlv.DeviceElementIdRef == isoDeviceElementHierarchy.DeviceElement.DeviceElementId);
             foreach (ISODataLogValue dlv in deviceElementDLVs)
             {
-                IEnumerable<WorkingData> newWorkingDatas = Map(dlv, isoSpatialRows, deviceElementUse, dlv.Order, pendingDeviceElementUses, isoDeviceElementHierarchy);
+                IEnumerable<WorkingData> newWorkingDatas = Map(dlv, 
+                                                               isoSpatialRows,
+                                                               deviceElementUse,
+                                                               dlv.Order,
+                                                               pendingDeviceElementUses,
+                                                               isoDeviceElementHierarchy);
                 if (newWorkingDatas.Count() > 0)
                 {
                     int ddi = dlv.ProcessDataDDI.AsInt32DDI();
@@ -100,6 +126,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                 //Numeric Representations
                 NumericWorkingData numericMeter = MapNumericMeter(dlv, deviceElementUse.Id.ReferenceId);
                 DataLogValuesByWorkingDataID.Add(numericMeter.Id.ReferenceId, dlv);
+                ISODeviceElementIDsByWorkingDataID.Add(numericMeter.Id.ReferenceId, dlv.DeviceElementIdRef);
                 workingDatas.Add(numericMeter);
                 return workingDatas;
             }
@@ -111,6 +138,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                 foreach (ISOEnumeratedMeter enumeratedMeter in isoEnumeratedMeters)
                 {
                     DataLogValuesByWorkingDataID.Add(enumeratedMeter.Id.ReferenceId, dlv);
+                    ISODeviceElementIDsByWorkingDataID.Add(enumeratedMeter.Id.ReferenceId, dlv.DeviceElementIdRef);
                     enumeratedMeter.DeviceElementUseId = deviceElementUse.Id.ReferenceId;
                 }
                 workingDatas.AddRange(isoEnumeratedMeters);
@@ -129,6 +157,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                 proprietaryWorkingData.UnitOfMeasure = AgGateway.ADAPT.Representation.UnitSystem.UnitSystemManager.GetUnitOfMeasure("count"); //Best we can do
 
                 DataLogValuesByWorkingDataID.Add(proprietaryWorkingData.Id.ReferenceId, dlv);
+                ISODeviceElementIDsByWorkingDataID.Add(proprietaryWorkingData.Id.ReferenceId, dlv.DeviceElementIdRef);
                 workingDatas.Add(proprietaryWorkingData);
             }
             return workingDatas;
@@ -141,6 +170,17 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                 UnitOfMeasure = RepresentationMapper.GetUnitForDdi(dlv.ProcessDataDDI.AsInt32DDI()),
                 DeviceElementUseId = deviceElementUseId,
                 Representation = RepresentationMapper.Map(dlv.ProcessDataDDI.AsInt32DDI())
+            };
+            return meter;
+        }
+
+        private NumericWorkingData CreateProductIndexWorkingData(int deviceElementUseId)
+        {
+            var meter = new NumericWorkingData
+            {
+                UnitOfMeasure = UnitSystemManager.GetUnitOfMeasure("count"),
+                DeviceElementUseId = deviceElementUseId,
+                Representation = RepresentationMapper.GetRepresentation("vrProductIndex")
             };
             return meter;
         }

--- a/ISOv4Plugin/Mappers/TimeLogMapper.cs
+++ b/ISOv4Plugin/Mappers/TimeLogMapper.cs
@@ -299,7 +299,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
         {
             WorkingDataMapper workingDataMapper = new WorkingDataMapper(new EnumeratedMeterFactory(), TaskDataMapper);
             SectionMapper sectionMapper = new SectionMapper(workingDataMapper, TaskDataMapper);
-            SpatialRecordMapper spatialMapper = new SpatialRecordMapper(new RepresentationValueInterpolator(), sectionMapper, workingDataMapper);
+            SpatialRecordMapper spatialMapper = new SpatialRecordMapper(new RepresentationValueInterpolator(), sectionMapper, workingDataMapper, TaskDataMapper);
             IEnumerable<ISOSpatialRow> isoRecords = ReadTimeLog(isoTimeLog, this.TaskDataPath);
             if (isoRecords != null)
             {
@@ -330,19 +330,32 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                 {
                     OperationData operationData = new OperationData();
 
+                    //Determine products
+                    Dictionary<string, List<ISOProductAllocation>> productAllocations = GetProductAllocationsByDeviceElement(loggedTask, dvc);
+                    List<int> productIDs = GetDistinctProductIDs(TaskDataMapper, productAllocations);
+                    int? operationProductID = null;  //In future versions this will be a list
+                    if (productIDs.Count == 1)
+                    {
+                        operationProductID = productIDs.Single();
+                    }
+
                     //This line will necessarily invoke a spatial read in order to find 
                     //1)The correct number of CondensedWorkState working datas to create 
                     //2)Any Widths and Offsets stored in the spatial data
-                    IEnumerable<DeviceElementUse> sections = sectionMapper.Map(time, isoRecords, operationData.Id.ReferenceId, loggedDeviceElementsByDevice[dvc]);
+                    IEnumerable<DeviceElementUse> sections = sectionMapper.Map(time,
+                                                                               isoRecords,
+                                                                               operationData.Id.ReferenceId,
+                                                                               loggedDeviceElementsByDevice[dvc],
+                                                                               productAllocations);
 
                     var workingDatas = sections != null ? sections.SelectMany(x => x.GetWorkingDatas()).ToList() : new List<WorkingData>();
 
-                    operationData.GetSpatialRecords = () => spatialMapper.Map(isoRecords, workingDatas);
+                    operationData.GetSpatialRecords = () => spatialMapper.Map(isoRecords, workingDatas, productAllocations);
                     operationData.MaxDepth = sections.Count() > 0 ? sections.Select(s => s.Depth).Max() : 0;
                     operationData.GetDeviceElementUses = x => sectionMapper.ConvertToBaseTypes(sections.Where(s => s.Depth == x).ToList());
                     operationData.PrescriptionId = prescriptionID;
                     operationData.OperationType = GetOperationTypeFromLoggingDevices(time);
-                    operationData.ProductId = GetProductIDForOperationData(loggedTask, dvc);
+                    operationData.ProductId = operationProductID; 
                     operationData.SpatialRecordCount = isoRecords.Count();
                     operationDatas.Add(operationData);
                 }
@@ -352,34 +365,38 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             return null;
         }
 
-        private int? GetProductIDForOperationData(ISOTask loggedTask, ISODevice dvc)
+        internal static List<int> GetDistinctProductIDs(TaskDataMapper taskDataMapper, Dictionary<string, List<ISOProductAllocation>> productAllocations)
         {
-            if (loggedTask.ProductAllocations.Count == 1 || loggedTask.ProductAllocations.Select(p => p.ProductIdRef).Distinct().Count() == 1)
+            HashSet<int> productIDs = new HashSet<int>();
+            foreach (string detID in productAllocations.Keys)
             {
-                //There is only one product in the data
-                return TaskDataMapper.InstanceIDMap.GetADAPTID(loggedTask.ProductAllocations.First().ProductIdRef);
-            }
-            else
-            {
-                HashSet<string> productRefsForThisDevice = new HashSet<string>();
-                foreach (ISODeviceElement det in dvc.DeviceElements)
+                foreach (ISOProductAllocation pan in productAllocations[detID])
                 {
-                    foreach (ISOProductAllocation detMappedPan in loggedTask.ProductAllocations.Where(p => !string.IsNullOrEmpty(p.DeviceElementIdRef)))
+                    int? id = taskDataMapper.InstanceIDMap.GetADAPTID(pan.ProductIdRef);
+                    if (id.HasValue)
                     {
-                        productRefsForThisDevice.Add(detMappedPan.ProductIdRef);
+                        productIDs.Add(id.Value);
                     }
                 }
-                if (productRefsForThisDevice.Count == 1)
+            }
+            return productIDs.ToList();
+        }
+
+        private Dictionary<string, List<ISOProductAllocation>> GetProductAllocationsByDeviceElement(ISOTask loggedTask, ISODevice dvc)
+        {
+            Dictionary<string, List<ISOProductAllocation>> output = new Dictionary<string, List<ISOProductAllocation>>();
+            foreach (ISOProductAllocation pan in loggedTask.ProductAllocations.Where(p => !string.IsNullOrEmpty(p.DeviceElementIdRef)))
+            {
+                if (dvc.DeviceElements.Select(d => d.DeviceElementId).Contains(pan.DeviceElementIdRef)) //Filter PANs by this DVC
                 {
-                    //There is only one product represented on this device
-                    return TaskDataMapper.InstanceIDMap.GetADAPTID(productRefsForThisDevice.Single());
-                }
-                else
-                {
-                    //Unable to reconcile a single product
-                    return null;
+                    if (!output.ContainsKey(pan.DeviceElementIdRef))
+                    {
+                        output.Add(pan.DeviceElementIdRef, new List<ISOProductAllocation>());
+                    }
+                    output[pan.DeviceElementIdRef].Add(pan);
                 }
             }
+            return output;
         }
 
         private OperationTypeEnum GetOperationTypeFromLoggingDevices(ISOTime time)

--- a/ISOv4Plugin/Mappers/TimeLogMapper.cs
+++ b/ISOv4Plugin/Mappers/TimeLogMapper.cs
@@ -523,7 +523,12 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                         foreach (ISODataLogValue fixedValue in templateTime.DataLogValues.Where(dlv => dlv.ProcessDataValue.HasValue && !EnumeratedMeterFactory.IsCondensedMeter(dlv.ProcessDataDDI.AsInt32DDI())))
                         {
                             byte order = (byte)templateTime.DataLogValues.IndexOf(fixedValue);
-                            record.SpatialValues.Add(CreateSpatialValue(templateTime, order, fixedValue.ProcessDataValue.Value));
+                            if (record.SpatialValues.Any(s => s.Id == order)) //Check to ensure the binary data didn't already write this value
+                            {
+                                //Per the spec, any fixed value in the XML applies to all rows; as such, replace what was read from the binary
+                                SpatialValue matchingValue = record.SpatialValues.Single(s => s.Id == order);
+                                matchingValue.DataLogValue = fixedValue;
+                            }
                         }
 
                         yield return record;

--- a/ISOv4Plugin/Representation/RepresentationMapper.cs
+++ b/ISOv4Plugin/Representation/RepresentationMapper.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * ISO standards can be purchased through the ANSI webstore at https://webstore.ansi.org
 */
 
@@ -40,16 +40,36 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Representation
                 var matchingDdi = _ddis[ddi];
                 var representation = RepresentationManager.Instance.Representations.FirstOrDefault(x => x.Ddi.GetValueOrDefault() == matchingDdi.Id);
 
-                var numericRep = representation as NumericRepresentation;
-                if (numericRep != null)
-                    return numericRep.ToModelRepresentation();
-
-                var enumeratedRep = representation as EnumeratedRepresentation;
-
-                if (enumeratedRep != null)
-                    return enumeratedRep.ToModelRepresentation();
+                AdaptRepresentation adaptRep = GetADAPTRepresentation(representation);
+                if (adaptRep != null)
+                {
+                    return adaptRep;
+                }
 
                 return new ApplicationDataModel.Representations.NumericRepresentation { Code = ddi.ToString("X4"), CodeSource = RepresentationCodeSourceEnum.ISO11783_DDI };
+            }
+            return null;
+        }
+
+        private static AdaptRepresentation GetADAPTRepresentation(ADAPT.Representation.RepresentationSystem.Representation representation)
+        {
+            var numericRep = representation as NumericRepresentation;
+            if (numericRep != null)
+                return numericRep.ToModelRepresentation();
+
+            var enumeratedRep = representation as EnumeratedRepresentation;
+            if (enumeratedRep != null)
+                return enumeratedRep.ToModelRepresentation();
+
+            return null;
+        }
+
+        public static AdaptRepresentation GetRepresentation(string code)
+        {
+            var matchingRepresentation = RepresentationManager.Instance.Representations[code];
+            if (matchingRepresentation != null)
+            {
+                return GetADAPTRepresentation(matchingRepresentation);
             }
             return null;
         }


### PR DESCRIPTION
Added reporting of Product Allocations via vrProductIndex when there are multiple products on a task.
Moved bin elements to a unique depth in the device hierarchy.
Fixed issues where a DLV value was reported in the TLG.xml in addition to TLG.bin






