### PR TITLE
Fixing Multiple DDI Match Mapping and Allowing import of Miscategorized Tasks

### DIFF
--- a/AgGatewayISOPlugin.nuspec
+++ b/AgGatewayISOPlugin.nuspec
@@ -13,7 +13,7 @@
     <tags>agriculture aggateway adapt isoxml isoxmlv4 11783 11783-10</tags>
     <dependencies>
       <!-- Any 2.x.x version -->
-      <dependency id="AgGatewayADAPTFramework" version="[2,3)" />
+      <dependency id="AgGatewayADAPTFramework" version="[2.0.2,3)" />
     </dependencies>
     <references>
       <reference file="AgGateway.ADAPT.ISOv4Plugin.dll"/>

--- a/ISOv4Plugin/ISOv4Plugin.csproj
+++ b/ISOv4Plugin/ISOv4Plugin.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AgGatewayADAPTFramework" Version="2.0.1" />
+    <PackageReference Include="AgGatewayADAPTFramework" Version="2.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ISOv4Plugin/Mappers/TaskDataMapper.cs
+++ b/ISOv4Plugin/Mappers/TaskDataMapper.cs
@@ -351,7 +351,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             }
 
             IEnumerable<ISOTask> prescribedTasks = taskData.ChildElements.OfType<ISOTask>().Where(t => t.IsWorkItemTask);
-            IEnumerable<ISOTask> loggedTasks = taskData.ChildElements.OfType<ISOTask>().Where(t => t.IsLoggedDataTask);
+            IEnumerable<ISOTask> loggedTasks = taskData.ChildElements.OfType<ISOTask>().Where(t => t.IsLoggedDataTask || t.TimeLogs.Any());
             if (prescribedTasks.Any() || loggedTasks.Any())
             {
                 TaskMapper taskMapper = new TaskMapper(this);

--- a/ISOv4Plugin/Representation/RepresentationMapper.cs
+++ b/ISOv4Plugin/Representation/RepresentationMapper.cs
@@ -38,12 +38,19 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Representation
             if (_ddis.ContainsKey(ddi))
             {
                 var matchingDdi = _ddis[ddi];
-                var representation = RepresentationManager.Instance.Representations.FirstOrDefault(x => x.Ddi.GetValueOrDefault() == matchingDdi.Id);
-
-                AdaptRepresentation adaptRep = GetADAPTRepresentation(representation);
-                if (adaptRep != null)
+                var representations = RepresentationManager.Instance.Representations.Where(x => x.Ddi.GetValueOrDefault() == matchingDdi.Id);
+                if (representations.Any())
                 {
-                    return adaptRep;
+                    //Default the representation mapping approprately on import
+                    var representation = representations.FirstOrDefault(r => r.IsDefaultRepresentationForDDI)
+                                            ??
+                                         representations.First();
+
+                    AdaptRepresentation adaptRep = GetADAPTRepresentation(representation);
+                    if (adaptRep != null)
+                    {
+                        return adaptRep;
+                    }
                 }
 
                 return new ApplicationDataModel.Representations.NumericRepresentation { Code = ddi.ToString("X4"), CodeSource = RepresentationCodeSourceEnum.ISO11783_DDI };


### PR DESCRIPTION
Upgrade to Framework 2.0.2
Fixing Import Mappings for Multiple DDI Matches
Allowing import of Miscategorized Tasks