### PR TITLE
Update XmlExtensions.cs

### DIFF
--- a/ISOv4Plugin/ExtensionMethods/XmlExtensions.cs
+++ b/ISOv4Plugin/ExtensionMethods/XmlExtensions.cs
@@ -223,7 +223,14 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ExtensionMethods
             if (!attributeValue.HasValue)
                 return;
 
-            writer.WriteAttributeString(attributeName, attributeValue.Value.ToString());
+            if (typeof(T) == typeof(decimal))
+            {
+                decimal helper = (decimal)(object)attributeValue;
+                writer.WriteAttributeString(attributeName, helper.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            }
+            else {
+                writer.WriteAttributeString(attributeName, attributeValue.Value.ToString());
+            }
         }
     }
 }


### PR DESCRIPTION
With German system settings, WGS84 coordinates were serialized to the ISOXML files using the , as the decimal sign...