### PR TITLE
Case sensitive filesystem bug fix.

### DIFF
--- a/ISOv4Plugin/ISOModels/ISOGrid.cs
+++ b/ISOv4Plugin/ISOModels/ISOGrid.cs
@@ -78,6 +78,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ISOModels
         {
             List<int> values = new List<int>();
             string filePath = Path.ChangeExtension(Path.Combine(dataPath, Filename), ".bin");
+            filePath = dataPath.GetDirectoryFiles(filePath, SearchOption.TopDirectoryOnly).FirstOrDefault();
             using (var fileStream = File.OpenRead(filePath))
             {
                 int treatmentZoneId;
@@ -104,6 +105,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ISOModels
             List<List<double>> productRates = new List<List<double>>();
             Dictionary<string, ISOUnit> unitsByDDI = new Dictionary<string, ISOUnit>();
             string filePath = Path.ChangeExtension(Path.Combine(dataPath, Filename), ".bin");
+            filePath = dataPath.GetDirectoryFiles(filePath, SearchOption.TopDirectoryOnly).FirstOrDefault();
             using (var fileStream = File.OpenRead(filePath))
             {
                 var bytes = new byte[4];


### PR DESCRIPTION
Bug fix for case sensitive file systems.  This is needed if running on linux and the .bin file extension is upper case.