### PR TITLE
Issue 92 Workaround, UOM Parsing Fix

### DIFF
--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/EnumeratedMeterFactory.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/EnumeratedMeterFactory.cs
@@ -1,4 +1,4 @@
-﻿namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
+namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
 {
     public interface IEnumeratedMeterFactory
     {
@@ -28,8 +28,8 @@
                 return new NetWeightStateMeterCreator((int)ddi);
             if (ddi == 240)
                 return new ActualLoadingSystemStatusMeterCreator((int)ddi);
-            if (ddi >= 290 && ddi < 305)
-                return new CondensedWorkStateMeterCreator((int)ddi, 290);
+            //if (ddi >= 290 && ddi < 305)     //Github Issue 92
+            //    return new CondensedWorkStateMeterCreator((int)ddi, 290);
             if (ddi >= 367 && ddi <= 382)
                 return new CondensedSectionOverrideStateMeterCreator((int)ddi);
             return null;

--- a/ISOv4Plugin/Representation/DdiLoader.cs
+++ b/ISOv4Plugin/Representation/DdiLoader.cs
@@ -124,7 +124,17 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Representation
             if (unitDescriptionLocation == -1)
                 unitDescriptionLocation = value.IndexOf(" (", StringComparison.Ordinal);
 
-            return value.Substring(6, unitDescriptionLocation - 6);
+            string parsedUnit = value.Substring(6, unitDescriptionLocation - 6);
+            if (parsedUnit.Contains("("))
+            {
+                //This unit description contained extraneous parenthesized information left of the hyphen
+                unitDescriptionLocation = parsedUnit.IndexOf(" (", StringComparison.Ordinal);
+                return parsedUnit.Substring(0, unitDescriptionLocation);
+            }
+            else
+            {
+                return parsedUnit;
+            }
         }
     }
 }


### PR DESCRIPTION
Suppressing Setpoint Workstate data in preference to incorrectly mapping to an actual state.

Alternatives longer term would be to add a representation in ADAPT for this concept (which is rare), or pass the data through as an ISO representation (which I initially pursued, leading to a cascade of changes including in the DDILoader, and handling null units in the RepresentationMapper, before ultimately setting aside the effort due to the non-existence of a "None" unit of measure in ADAPT).