### PR TITLE
CondensedWorkstate, Polygon Exterior Ring and Binary Y-Offset Data fixes

### DIFF
--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/ActualLoadingSystemStatusMeterCreator.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/ActualLoadingSystemStatusMeterCreator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
 using AgGateway.ADAPT.ApplicationDataModel.Representations;
+using AgGateway.ADAPT.ISOv4Plugin.ISOModels;
 using AgGateway.ADAPT.ISOv4Plugin.ObjectModel;
 using AgGateway.ADAPT.Representation.RepresentationSystem;
 using AgGateway.ADAPT.Representation.RepresentationSystem.ExtensionMethods;
@@ -20,7 +21,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             DDI = ddi;
         }
 
-        public List<ISOEnumeratedMeter> CreateMeters(IEnumerable<ISOSpatialRow> spatialRows)
+        public List<ISOEnumeratedMeter> CreateMeters(IEnumerable<ISOSpatialRow> spatialRows, ISODataLogValue dlv)
         {
             var unloadingMeter = new ISOEnumeratedMeter
             {

--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/CondensedWorkStateMeterCreator.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/CondensedWorkStateMeterCreator.cs
@@ -9,6 +9,7 @@ using AgGateway.ADAPT.Representation.RepresentationSystem.ExtensionMethods;
 using EnumeratedRepresentation = AgGateway.ADAPT.ApplicationDataModel.Representations.EnumeratedRepresentation;
 using EnumerationMember = AgGateway.ADAPT.Representation.RepresentationSystem.EnumerationMember;
 using AgGateway.ADAPT.ISOv4Plugin.ExtensionMethods;
+using AgGateway.ADAPT.ISOv4Plugin.ISOModels;
 
 namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
 {
@@ -102,7 +103,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
 
         public Dictionary<int, EnumerationMember> SectionValueToEnumerationMember { get; set; } 
 
-        public List<ISOEnumeratedMeter> CreateMeters(IEnumerable<ISOSpatialRow> spatialRows)
+        public List<ISOEnumeratedMeter> CreateMeters(IEnumerable<ISOSpatialRow> spatialRows, ISODataLogValue dlv)
         {
             //We need to find a row of data with the value in order to create the correct number of meters.
             var spatialRowWithDdi = spatialRows.FirstOrDefault(x => x.SpatialValues.Any(y => y.DataLogValue.ProcessDataDDI.AsInt32DDI() == DDI));
@@ -110,7 +111,8 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             int numberOfSections = 0;
             if (spatialRowWithDdi != null)
             {
-                var spatialValue = spatialRowWithDdi.SpatialValues.First(x => x.DataLogValue.ProcessDataDDI.AsInt32DDI() == DDI);
+                var spatialValue = spatialRowWithDdi.SpatialValues.First(x => x.DataLogValue.ProcessDataDDI.AsInt32DDI() == DDI &&
+                                                                              x.DataLogValue.DeviceElementIdRef == dlv.DeviceElementIdRef);
                 numberOfSections = GetNumberOfInstalledSections(spatialValue);
             }
 

--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/ConnectorTypeMeterCreator.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/ConnectorTypeMeterCreator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
 using AgGateway.ADAPT.ApplicationDataModel.Representations;
+using AgGateway.ADAPT.ISOv4Plugin.ISOModels;
 using AgGateway.ADAPT.ISOv4Plugin.ObjectModel;
 using AgGateway.ADAPT.Representation.RepresentationSystem;
 using AgGateway.ADAPT.Representation.RepresentationSystem.ExtensionMethods;
@@ -20,7 +21,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             DDI = ddi;
         }
 
-        public List<ISOEnumeratedMeter> CreateMeters(IEnumerable<ISOSpatialRow> spatialRows)
+        public List<ISOEnumeratedMeter> CreateMeters(IEnumerable<ISOSpatialRow> spatialRows, ISODataLogValue dlv)
         {
             var meter = new ISOEnumeratedMeter
             {

--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/IEnumeratedMeterCreator.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/IEnumeratedMeterCreator.cs
@@ -3,6 +3,7 @@ using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
 using AgGateway.ADAPT.ApplicationDataModel.Representations;
 using AgGateway.ADAPT.ISOv4Plugin.ObjectModel;
 using System;
+using AgGateway.ADAPT.ISOv4Plugin.ISOModels;
 
 namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
 {
@@ -10,7 +11,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
     {
         int DDI { get; set; }
         int StartingSection { get; }
-        List<ISOEnumeratedMeter> CreateMeters(IEnumerable<ISOSpatialRow> spatialRows);  //CondensedWorkstateMeter is necessarily forcing CreateMeters process to read spatial data to create meters.
+        List<ISOEnumeratedMeter> CreateMeters(IEnumerable<ISOSpatialRow> spatialRows, ISODataLogValue dlv);  //CondensedWorkstateMeter is necessarily forcing CreateMeters process to read spatial data to create meters.
         EnumeratedValue GetValueForMeter(SpatialValue value, ISOEnumeratedMeter workingData);
         UInt32 GetMetersValue(List<WorkingData> meters, SpatialRecord spatialRecord);
     }

--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/NetWeightStateMeterCreator.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/NetWeightStateMeterCreator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
 using AgGateway.ADAPT.ApplicationDataModel.Representations;
+using AgGateway.ADAPT.ISOv4Plugin.ISOModels;
 using AgGateway.ADAPT.ISOv4Plugin.ObjectModel;
 using AgGateway.ADAPT.Representation.RepresentationSystem;
 using AgGateway.ADAPT.Representation.RepresentationSystem.ExtensionMethods;
@@ -20,7 +21,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             DDI = ddi;
         }
 
-        public List<ISOEnumeratedMeter> CreateMeters(IEnumerable<ISOSpatialRow> spatialRows)
+        public List<ISOEnumeratedMeter> CreateMeters(IEnumerable<ISOSpatialRow> spatialRows, ISODataLogValue dlv)
         {
             var meter = new ISOEnumeratedMeter
             {

--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/PrescriptionControlMeterCreator.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/PrescriptionControlMeterCreator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
 using AgGateway.ADAPT.ApplicationDataModel.Representations;
+using AgGateway.ADAPT.ISOv4Plugin.ISOModels;
 using AgGateway.ADAPT.ISOv4Plugin.ObjectModel;
 using AgGateway.ADAPT.Representation.RepresentationSystem;
 using AgGateway.ADAPT.Representation.RepresentationSystem.ExtensionMethods;
@@ -21,7 +22,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
         public int DDI { get; set; }
         public int StartingSection { get; private set; }
         
-        public List<ISOEnumeratedMeter> CreateMeters(IEnumerable<ISOSpatialRow> spatialRows)
+        public List<ISOEnumeratedMeter> CreateMeters(IEnumerable<ISOSpatialRow> spatialRows, ISODataLogValue dlv)
         {
             var meter = new ISOEnumeratedMeter
             {

--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/SectionControlStateMeterCreator.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/SectionControlStateMeterCreator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
 using AgGateway.ADAPT.ApplicationDataModel.Representations;
+using AgGateway.ADAPT.ISOv4Plugin.ISOModels;
 using AgGateway.ADAPT.ISOv4Plugin.ObjectModel;
 using AgGateway.ADAPT.Representation.RepresentationSystem;
 using AgGateway.ADAPT.Representation.RepresentationSystem.ExtensionMethods;
@@ -20,7 +21,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             DDI = ddi;
         }
 
-        public List<ISOEnumeratedMeter> CreateMeters(IEnumerable<ISOSpatialRow> spatialRows)
+        public List<ISOEnumeratedMeter> CreateMeters(IEnumerable<ISOSpatialRow> spatialRows, ISODataLogValue dlv)
         {
             var meter = new ISOEnumeratedMeter
             {

--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/SkyConditionsMeterCreator.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/SkyConditionsMeterCreator.cs
@@ -7,6 +7,7 @@ using AgGateway.ADAPT.ISOv4Plugin.ObjectModel;
 using AgGateway.ADAPT.Representation.RepresentationSystem;
 using AgGateway.ADAPT.Representation.RepresentationSystem.ExtensionMethods;
 using AgGateway.ADAPT.ISOv4Plugin.ExtensionMethods;
+using AgGateway.ADAPT.ISOv4Plugin.ISOModels;
 
 namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
 {
@@ -21,7 +22,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             DDI = ddi;
         }
 
-        public List<ISOEnumeratedMeter> CreateMeters(IEnumerable<ISOSpatialRow> spatialRows)
+        public List<ISOEnumeratedMeter> CreateMeters(IEnumerable<ISOSpatialRow> spatialRows, ISODataLogValue dlv)
         {
             var meter = new ISOEnumeratedMeter
             {

--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/WorkStateMeterCreator.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/WorkStateMeterCreator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
 using AgGateway.ADAPT.ApplicationDataModel.Representations;
+using AgGateway.ADAPT.ISOv4Plugin.ISOModels;
 using AgGateway.ADAPT.ISOv4Plugin.ObjectModel;
 using AgGateway.ADAPT.Representation.RepresentationSystem;
 using AgGateway.ADAPT.Representation.RepresentationSystem.ExtensionMethods;
@@ -20,7 +21,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
         public int DDI { get; set; }
         public int StartingSection { get; private set; }
 
-        public List<ISOEnumeratedMeter> CreateMeters(IEnumerable<ISOSpatialRow> spatialRows)
+        public List<ISOEnumeratedMeter> CreateMeters(IEnumerable<ISOSpatialRow> spatialRows, ISODataLogValue dlv)
         {
             var meter = new ISOEnumeratedMeter
             {

--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/WorkingDataMapper.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/WorkingDataMapper.cs
@@ -134,7 +134,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             if (meterCreator != null)
             {
                 //Enumerated Representations
-                var isoEnumeratedMeters = meterCreator.CreateMeters(isoSpatialRows);
+                var isoEnumeratedMeters = meterCreator.CreateMeters(isoSpatialRows, dlv);
                 foreach (ISOEnumeratedMeter enumeratedMeter in isoEnumeratedMeters)
                 {
                     DataLogValuesByWorkingDataID.Add(enumeratedMeter.Id.ReferenceId, dlv);

--- a/ISOv4Plugin/Mappers/PolygonMapper.cs
+++ b/ISOv4Plugin/Mappers/PolygonMapper.cs
@@ -50,7 +50,10 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
 
             LineStringMapper lsgMapper = new LineStringMapper(TaskDataMapper);
             ISOPolygon.LineStrings = new List<ISOLineString>();
-            ISOPolygon.LineStrings.Add(lsgMapper.ExportLinearRing(adaptPolygon.ExteriorRing, ISOLineStringType.PolygonExterior));
+            if (adaptPolygon.ExteriorRing != null)
+            {
+                ISOPolygon.LineStrings.Add(lsgMapper.ExportLinearRing(adaptPolygon.ExteriorRing, ISOLineStringType.PolygonExterior));
+            }
             if (adaptPolygon.InteriorRings != null)
             {
                 foreach(LinearRing interiorRing in adaptPolygon.InteriorRings)

--- a/ISOv4Plugin/ObjectModel/DeviceElementHierarchy.cs
+++ b/ISOv4Plugin/ObjectModel/DeviceElementHierarchy.cs
@@ -430,7 +430,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ObjectModel
                                                                                                     s.DataLogValue.ProcessDataDDI == "0087"));
             if (firstYOffset != null)
             {
-                offset = firstYOffset.SpatialValues.Single(s => s.DataLogValue.DeviceElementIdRef == isoDeviceElementID &&
+                offset = firstYOffset.SpatialValues.First(s => s.DataLogValue.DeviceElementIdRef == isoDeviceElementID &&
                                                                                                     s.DataLogValue.ProcessDataDDI == "0087").Value;
                 return (int)offset;
             }


### PR DESCRIPTION
Fixing 3 issues: 
-Null check on exterior rings
-Multiple Y-Offset vales in binary data for same device element, 
-CondensedWorkstate logic fails to account for governing device element where multiple.