### PR TITLE
Allow reading binary files by multiple readers at the same time

### DIFF
--- a/ISOv4Plugin/Mappers/TimeLogMapper.cs
+++ b/ISOv4Plugin/Mappers/TimeLogMapper.cs
@@ -496,7 +496,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                 if (!File.Exists(fileName))
                     yield break;
 
-                using (var binaryReader = new System.IO.BinaryReader(File.Open(fileName, FileMode.Open)))
+                using (var binaryReader = new System.IO.BinaryReader(File.Open(fileName, FileMode.Open, FileAccess.Read, FileShare.Read)))
                 {
                     while (binaryReader.BaseStream.Position < binaryReader.BaseStream.Length)
                     {


### PR DESCRIPTION
We are using ISO plugin for processing data in our project. While running integration tests against several data sets using XUnit framework, System.IO.IOException with a message "The process cannot access the file x because it is being used by another process" is thrown.

To solve this, a change is proposed in this PR to open binary file with read sharing access allowing multiple readers to access same file at the same time.