### PR TITLE
Remove 50 row limitation on finding a width from spatial data when Sp…

### DIFF
--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/SectionMapper.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/SectionMapper.cs
@@ -12,7 +12,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
 {
     public interface ISectionMapper
     {
-        List<DeviceElementUse> Map(ISOTime time, IEnumerable<ISOSpatialRow> isoRecords, int operationDataId, IEnumerable<string> isoDeviceElementIDs, Dictionary<string, List<ISOProductAllocation>> isoProductAllocations, bool useDeferredExecution);
+        List<DeviceElementUse> Map(ISOTime time, IEnumerable<ISOSpatialRow> isoRecords, int operationDataId, IEnumerable<string> isoDeviceElementIDs, Dictionary<string, List<ISOProductAllocation>> isoProductAllocations);
         List<DeviceElementUse> ConvertToBaseTypes(List<DeviceElementUse> meters);
     }
 
@@ -30,8 +30,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                                           IEnumerable<ISOSpatialRow> isoRecords,
                                           int operationDataId,
                                           IEnumerable<string> isoDeviceElementIDs,
-                                          Dictionary<string, List<ISOProductAllocation>> isoProductAllocations,
-                                          bool useDeferredExecution)
+                                          Dictionary<string, List<ISOProductAllocation>> isoProductAllocations)
         {
             var sections = new List<DeviceElementUse>();
             foreach (string isoDeviceElementID in isoDeviceElementIDs)
@@ -59,7 +58,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                         }
 
                         //Read any spatially-listed widths/offsets on this data onto the DeviceElementConfiguration objects
-                        hierarchy.SetWidthsAndOffsetsFromSpatialData(time, isoRecords, config, RepresentationMapper, useDeferredExecution);
+                        hierarchy.SetWidthsAndOffsetsFromSpatialData(time, isoRecords, config, RepresentationMapper);
 
                         deviceElementUse = sections.FirstOrDefault(d => d.DeviceConfigurationId == config.Id.ReferenceId);
                         if (deviceElementUse == null)

--- a/ISOv4Plugin/Mappers/TimeLogMapper.cs
+++ b/ISOv4Plugin/Mappers/TimeLogMapper.cs
@@ -371,8 +371,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                                                                                isoRecords,
                                                                                operationData.Id.ReferenceId,
                                                                                loggedDeviceElementsByDevice[dvc],
-                                                                               productAllocations,
-                                                                               useDeferredExecution);
+                                                                               productAllocations);
 
                     var workingDatas = sections != null ? sections.SelectMany(x => x.GetWorkingDatas()).ToList() : new List<WorkingData>();
 

--- a/ISOv4Plugin/ObjectModel/DeviceElementHierarchy.cs
+++ b/ISOv4Plugin/ObjectModel/DeviceElementHierarchy.cs
@@ -296,12 +296,12 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ObjectModel
             }
         }
 
-        public void SetWidthsAndOffsetsFromSpatialData(ISOTime time, IEnumerable<ISOSpatialRow> isoRecords, DeviceElementConfiguration config, RepresentationMapper representationMapper, bool useDeferredExecution)
+        public void SetWidthsAndOffsetsFromSpatialData(ISOTime time, IEnumerable<ISOSpatialRow> isoRecords, DeviceElementConfiguration config, RepresentationMapper representationMapper)
         {
             //Set values on this object and associated DeviceElementConfiguration 
             if (Width == null)
             {
-                Width = GetWidthFromSpatialData(time, isoRecords, DeviceElement.DeviceElementId, representationMapper, useDeferredExecution);
+                Width = GetWidthFromSpatialData(time, isoRecords, DeviceElement.DeviceElementId, representationMapper);
             }
 
             if (config.Offsets == null)
@@ -382,7 +382,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ObjectModel
             }
         }
 
-        private int? GetWidthFromSpatialData(ISOTime time, IEnumerable<ISOSpatialRow> isoRecords, string isoDeviceElementID, RepresentationMapper representationMapper, bool useDeferredExecution)
+        private int? GetWidthFromSpatialData(ISOTime time, IEnumerable<ISOSpatialRow> isoRecords, string isoDeviceElementID, RepresentationMapper representationMapper)
         {
             double maxWidth = 0d;
             string updatedWidthDDI = null;
@@ -420,13 +420,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ObjectModel
                 else
                 {
                     IEnumerable<ISOSpatialRow> rows = isoRecords.Where(r => r.SpatialValues.Any(s => s.DataLogValue.DeviceElementIdRef == isoDeviceElementID &&
-                                                                                                     s.DataLogValue.ProcessDataDDI == "0043"));
-                    if (useDeferredExecution)
-                    {
-                        //Limit iteration to first 50 rows for performance
-                        rows = rows.Take(50);
-                    }
-                                                               
+                                                                                                     s.DataLogValue.ProcessDataDDI == "0043"));                                                               
                     if (rows.Any())
                     {
                         foreach (ISOSpatialRow row in rows)


### PR DESCRIPTION
…atialRecordDeferredExecution set to true.

We determined there was really no benefit to the 50 row limitation, but there were times that there is a need to defer execution and iterate all rows.    The next time we have a breaking change, I may suggest flipping to defer execution by default.    Since there are cases code can behave differently by deferring the execution, I will leave the default to call the .ToList() so as not to cause any potential problems for plugin consumers.