### PR TITLE
Adding Pr_ISOXML_Attribute_Designator ContextItem to boundary polygons

### DIFF
--- a/ISOv4Plugin/Mappers/PolygonMapper.cs
+++ b/ISOv4Plugin/Mappers/PolygonMapper.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using AgGateway.ADAPT.ApplicationDataModel.Common;
 using AgGateway.ADAPT.ApplicationDataModel.Logistics;
 using AgGateway.ADAPT.ApplicationDataModel.Shapes;
 using AgGateway.ADAPT.ISOv4Plugin.ISOEnumerations;
@@ -67,7 +68,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             return ISOPolygon;
         }
 
-        #endregion Export 
+        #endregion Export
 
         #region Import
 
@@ -123,6 +124,11 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                     polygon.ExteriorRing = lsgMapper.ImportLinearRing(exteriorRing);
                 }
                 polygon.InteriorRings = lsgMapper.ImportLinearRings(interiorRings).ToList();
+
+                if (isoPolygon.PolygonDesignator != null)
+                {
+                    polygon.ContextItems.Add(new ContextItem() { Code = "Pr_ISOXML_Attribute_Designator", Value = isoPolygon.PolygonDesignator });
+                }
                 return polygon;
             }
             return null;
@@ -135,7 +141,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
         /// <returns></returns>
         public AttributeShape ImportAttributePolygon(ISOPolygon isoPolygon)
         {
-            Polygon boundaryPolygon = ImportBoundaryPolygon(isoPolygon); 
+            Polygon boundaryPolygon = ImportBoundaryPolygon(isoPolygon);
             if (boundaryPolygon != null && IsFieldAttributeType(isoPolygon))
             {
                 //The data has defined an explicit PLN type that maps to an attribute type


### PR DESCRIPTION
Hello, dealing with ISOXML files we need, when present, to import the designators (attribute B) of the boundary polygons.

In order to do that, we are submitting a couple of PRs,

this one in ISOV4Plugin, adds the code to populate appropriately the additional ContextItems field in the Shape class.
this PR depends on https://github.com/ADAPT/ADAPT/pull/301 that adds the field in the Shape class.