### PR TITLE
Protect against missing GRD.bin files

### DIFF
--- a/ISOv4Plugin/ISOModels/ISOGrid.cs
+++ b/ISOv4Plugin/ISOModels/ISOGrid.cs
@@ -80,6 +80,10 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ISOModels
             List<int> values = new List<int>();
             string filePath = Path.ChangeExtension(Path.Combine(dataPath, Filename), ".bin");
             filePath = dataPath.GetDirectoryFiles(filePath, SearchOption.TopDirectoryOnly).FirstOrDefault();
+            if (filePath == null)
+            {
+                return null;
+            }
             using (var fileStream = File.OpenRead(filePath))
             {
                 int treatmentZoneId;
@@ -107,6 +111,10 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ISOModels
             Dictionary<string, ISOUnit> unitsByDDI = new Dictionary<string, ISOUnit>();
             string filePath = Path.ChangeExtension(Path.Combine(dataPath, Filename), ".bin");
             filePath = dataPath.GetDirectoryFiles(filePath, SearchOption.TopDirectoryOnly).FirstOrDefault();
+            if (filePath == null)
+            {
+                return null;
+            }
             using (var fileStream = File.OpenRead(filePath))
             {
                 var bytes = new byte[4];

--- a/ISOv4Plugin/ObjectModel/GridDescriptor.cs
+++ b/ISOv4Plugin/ObjectModel/GridDescriptor.cs
@@ -106,12 +106,12 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ObjectModel
             if (grid.GridType == 1)
             {
                 TreatmentZoneCodes = grid.GetRatesForGridType1(dataPath);
-                return TreatmentZoneCodes.Count == RowCount * ColumnCount;
+                return TreatmentZoneCodes?.Count == RowCount * ColumnCount;
             }
             else if (grid.GridType == 2)
             {
                 ProductRates = grid.GetRatesForGridType2(dataPath, treatmentZone);
-                return ProductRates.Count == RowCount * ColumnCount;
+                return ProductRates?.Count == RowCount * ColumnCount;
             }
             else
             {


### PR DESCRIPTION
In some situations the `GRD.bin` files could be missing. This PR changes the plugin behavior to ignore them (instead of throwing a file access exception) same way as done for missing `TLG.bin` files.