### PR TITLE
Replacing Single with First on array that can have more than one element

### DIFF
--- a/ISOv4Plugin/ObjectModel/DeviceElementHierarchy.cs
+++ b/ISOv4Plugin/ObjectModel/DeviceElementHierarchy.cs
@@ -425,7 +425,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ObjectModel
                     {
                         foreach (ISOSpatialRow row in rows)
                         {
-                            double value = row.SpatialValues.Single(s => s.DataLogValue.DeviceElementIdRef == isoDeviceElementID && s.DataLogValue.ProcessDataDDI == "0043").Value;
+                            double value = row.SpatialValues.First(s => s.DataLogValue.DeviceElementIdRef == isoDeviceElementID && s.DataLogValue.ProcessDataDDI == "0043").Value;
                             if (value > maxWidth)
                             {
                                 maxWidth = value;


### PR DESCRIPTION
This will fix an exception we've been seeing on a dataset `Sequence contains more than one matching element`

Line 402 in ISOv4Plugin/ObjectModel/DeviceElementHierarchy.cs creates an array containing `any` row width SpatialValue.

Line 428 (Where the exception occurs) uses Single because there is an assumption that the array created on 402 will only have one element, because why would the data report more than one row width?

It turns out that some datasets report row width twice, which would cause an exception here.