### PR TITLE
Fixing Count() invocation that will unnecessarily iterate spatial dat…

### DIFF
--- a/ISOv4Plugin/ExtensionMethods/ExtensionMethods.cs
+++ b/ISOv4Plugin/ExtensionMethods/ExtensionMethods.cs
@@ -142,20 +142,26 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ExtensionMethods
             }
             if (userUnit != null)
             {
-                return userUnit.ToAdaptUnit();
+                UnitOfMeasure adaptUnit = null;
+                try
+                {
+                    adaptUnit = userUnit.ToAdaptUnit();
+                }
+                catch
+                {
+                    //Suppressing this as a non-critical exception
+                }
+                return adaptUnit;
             }
             return null;
         }
 
         public static UnitOfMeasure ToAdaptUnit(this ISOUnit isoUnit)
         {
-            //TODO move the contains logic upstream into the Representation assembly.
-            if (isoUnit != null &&
-                AgGateway.ADAPT.Representation.UnitSystem.InternalUnitSystemManager.Instance.UnitOfMeasures.Contains(isoUnit.Code))
-            {
-               return AgGateway.ADAPT.Representation.UnitSystem.UnitSystemManager.GetUnitOfMeasure(isoUnit.Code);
-            }
-            return null;
+            if (isoUnit == null)
+                return null;
+
+            return AgGateway.ADAPT.Representation.UnitSystem.UnitSystemManager.GetUnitOfMeasure(isoUnit.Code);
         }
 
         public static double ConvertFromIsoUnit(this ISOUnit unit, double value)

--- a/ISOv4Plugin/ISOModels/ISOCropType.cs
+++ b/ISOv4Plugin/ISOModels/ISOCropType.cs
@@ -49,7 +49,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ISOModels
             type.CropTypeId = typeNode.GetXmlNodeValue("@A");
             type.CropTypeDesignator = typeNode.GetXmlNodeValue("@B");
             type.ProductGroupIdRef = typeNode.GetXmlNodeValue("@C");
-
+            type.ProprietarySchemaExtensions = ReadProperietarySchemaExtensions(typeNode);
             XmlNodeList cvtNodes = typeNode.SelectNodes("CVT");
             if (cvtNodes != null)
             {

--- a/ISOv4Plugin/ISOModels/ISOCustomer.cs
+++ b/ISOv4Plugin/ISOModels/ISOCustomer.cs
@@ -65,6 +65,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ISOModels
             customer.CustomerMobile = customerNode.GetXmlNodeValue("@K");
             customer.CustomerFax = customerNode.GetXmlNodeValue("@L");
             customer.CustomerEmail = customerNode.GetXmlNodeValue("@M");
+            customer.ProprietarySchemaExtensions = ReadProperietarySchemaExtensions(customerNode);
             return customer;
         }
 

--- a/ISOv4Plugin/ISOModels/ISODevice.cs
+++ b/ISOv4Plugin/ISOModels/ISODevice.cs
@@ -66,7 +66,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ISOModels
             device.DeviceSerialNumber = node.GetXmlNodeValue("@E");
             device.DeviceStructureLabel = node.GetXmlNodeValue("@F");
             device.DeviceLocalizationLabel = node.GetXmlNodeValue("@G");
-
+            device.ProprietarySchemaExtensions = ReadProperietarySchemaExtensions(node);
             XmlNodeList detNodes = node.SelectNodes("DET");
             if (detNodes != null)
             {

--- a/ISOv4Plugin/ISOModels/ISODeviceElement.cs
+++ b/ISOv4Plugin/ISOModels/ISODeviceElement.cs
@@ -64,6 +64,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ISOModels
             item.DeviceElementDesignator = node.GetXmlNodeValue("@D");
             item.DeviceElementNumber = node.GetXmlNodeValueAsUInt("@E");
             item.ParentObjectId = node.GetXmlNodeValueAsUInt("@F");
+            item.ProprietarySchemaExtensions = ReadProperietarySchemaExtensions(node);
             XmlNodeList dorNodes = node.SelectNodes("DOR");
             if (dorNodes != null)
             {

--- a/ISOv4Plugin/ISOModels/ISOElement.cs
+++ b/ISOv4Plugin/ISOModels/ISOElement.cs
@@ -6,10 +6,7 @@ using System.Xml;
 using System.Collections.Generic;
 using AgGateway.ADAPT.ISOv4Plugin.ObjectModel;
 using System;
-using System.Reflection;
 using System.Linq.Expressions;
-using System.Linq;
-using System.Globalization;
 using AgGateway.ADAPT.ApplicationDataModel.ADM;
 
 namespace AgGateway.ADAPT.ISOv4Plugin.ISOModels
@@ -20,6 +17,21 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ISOModels
         {
             if (_xmlComments != null) _xmlComments.ForEach(s => xmlBuilder.WriteComment(s));
             return xmlBuilder;
+        }
+
+        public static Dictionary<string, string> ReadProperietarySchemaExtensions(XmlNode node)
+        {
+            Dictionary<string, string> output = new Dictionary<string, string>();
+            foreach (XmlAttribute attribute in node.Attributes)
+            {
+                if (attribute.Name.Length > 1 &&
+                    attribute.Name.StartsWith("P") &&
+                    !output.ContainsKey(attribute.Name))
+                {
+                    output.Add(attribute.Name, attribute.Value);
+                }
+            }
+            return output;
         }
 
         public virtual List<IError> Validate(List<IError> errors)
@@ -36,6 +48,11 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ISOModels
                 return _xmlComments;
             }
         }
+
+        /// <summary>
+        /// Manufacturer specific attributes added to the XML.
+        /// </summary>
+        public Dictionary<string, string> ProprietarySchemaExtensions { get; protected set; }
 
         #region Validation
         //Elected to use this custom validation logic vs. the Attribute based logic in System.ComponentModel.DataAnnotations

--- a/ISOv4Plugin/ISOModels/ISOFarm.cs
+++ b/ISOv4Plugin/ISOModels/ISOFarm.cs
@@ -53,6 +53,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ISOModels
             farm.FarmState = node.GetXmlNodeValue("@G");
             farm.FarmCountry = node.GetXmlNodeValue("@H");
             farm.CustomerIdRef = node.GetXmlNodeValue("@I");
+            farm.ProprietarySchemaExtensions = ReadProperietarySchemaExtensions(node);
             return farm;
         }
 

--- a/ISOv4Plugin/ISOModels/ISOPartfield.cs
+++ b/ISOv4Plugin/ISOModels/ISOPartfield.cs
@@ -72,7 +72,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ISOModels
             field.CropTypeIdRef = node.GetXmlNodeValue("@G");
             field.CropVarietyIdRef = node.GetXmlNodeValue("@H");
             field.FieldIdRef = node.GetXmlNodeValue("@I");
-
+            field.ProprietarySchemaExtensions = ReadProperietarySchemaExtensions(node);
             XmlNodeList plnNodes = node.SelectNodes("PLN");
             if (plnNodes != null)
             {

--- a/ISOv4Plugin/ISOModels/ISOProduct.cs
+++ b/ISOv4Plugin/ISOModels/ISOProduct.cs
@@ -75,6 +75,8 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ISOModels
                 product.ProductRelations.AddRange(ISOProductRelation.ReadXML(prnNodes));
             }
 
+            product.ProprietarySchemaExtensions = ReadProperietarySchemaExtensions(pdtNode);
+
             return product;
         }
 

--- a/ISOv4Plugin/ISOModels/ISOWorker.cs
+++ b/ISOv4Plugin/ISOModels/ISOWorker.cs
@@ -64,6 +64,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ISOModels
             worker.WorkerMobile = node.GetXmlNodeValue("@K");
             worker.WorkerLicenseNumber = node.GetXmlNodeValue("@L");
             worker.WorkerEmail = node.GetXmlNodeValue("@M");
+            worker.ProprietarySchemaExtensions = ReadProperietarySchemaExtensions(node);
             return worker;
         }
 

--- a/ISOv4Plugin/Mappers/BaseMapper.cs
+++ b/ISOv4Plugin/Mappers/BaseMapper.cs
@@ -79,9 +79,16 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             }
         }
 
-        protected List<ContextItem> ImportContextItems(string isoIDRef, string linkGroupDescription)
+        protected List<ContextItem> ImportContextItems(string isoIDRef, string linkGroupDescription, ISOElement element = null)
         {
-            return UniqueIDMapper.ImportContextItems(isoIDRef, linkGroupDescription);
+            //Read any data from the LinkList
+            List<ContextItem> output = UniqueIDMapper.ImportContextItemsFromLinkList(isoIDRef, linkGroupDescription);
+            if (element != null)
+            {
+                //Add any proprietary attributes on the element
+                output.AddRange(UniqueIDMapper.ImportContextItemsFromProprietaryAttributes(element));
+            }
+            return output;
         }
     }
 }

--- a/ISOv4Plugin/Mappers/CropTypeMapper.cs
+++ b/ISOv4Plugin/Mappers/CropTypeMapper.cs
@@ -104,7 +104,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
 
             //ID
             ImportIDs(adaptCrop.Id, isoCropType.CropTypeId);
-            adaptCrop.ContextItems = ImportContextItems(isoCropType.CropTypeId, "ADAPT_Context_Items:Crop");
+            adaptCrop.ContextItems = ImportContextItems(isoCropType.CropTypeId, "ADAPT_Context_Items:Crop", isoCropType);
 
             //Description
             adaptCrop.Name = isoCropType.CropTypeDesignator;

--- a/ISOv4Plugin/Mappers/CustomerMapper.cs
+++ b/ISOv4Plugin/Mappers/CustomerMapper.cs
@@ -98,7 +98,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
 
             //Customer ID
             ImportIDs(grower.Id, isoCustomer.CustomerId);
-            grower.ContextItems = ImportContextItems(isoCustomer.CustomerId, "ADAPT_Context_Items:Grower");
+            grower.ContextItems = ImportContextItems(isoCustomer.CustomerId, "ADAPT_Context_Items:Grower", isoCustomer);
 
             //Customer Name
             grower.Name = !string.IsNullOrEmpty(isoCustomer.CustomerFirstName) ? string.Concat(isoCustomer.CustomerFirstName," ", isoCustomer.CustomerLastName) : isoCustomer.CustomerLastName;

--- a/ISOv4Plugin/Mappers/DeviceElementMapper.cs
+++ b/ISOv4Plugin/Mappers/DeviceElementMapper.cs
@@ -349,7 +349,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             DeviceHierarchyElement deviceElementHierarchy = TaskDataMapper.DeviceElementHierarchies.GetMatchingElement(isoDeviceElement.DeviceElementId);
             //ID
             ImportIDs(deviceElement.Id, isoDeviceElement.DeviceElementId);
-            deviceElement.ContextItems = ImportContextItems(isoDeviceElement.DeviceElementId, "ADAPT_Context_Items:DeviceElement");
+            deviceElement.ContextItems = ImportContextItems(isoDeviceElement.DeviceElementId, "ADAPT_Context_Items:DeviceElement", isoDeviceElement);
 
             //Device ID
             int? deviceModelId = TaskDataMapper.InstanceIDMap.GetADAPTID(isoDeviceElement.Device.DeviceId);

--- a/ISOv4Plugin/Mappers/DeviceMapper.cs
+++ b/ISOv4Plugin/Mappers/DeviceMapper.cs
@@ -100,7 +100,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
 
             //ID
             ImportIDs(deviceModel.Id, isoDevice.DeviceId);
-            deviceModel.ContextItems = ImportContextItems(isoDevice.DeviceId, "ADAPT_Context_Items:DeviceModel");
+            deviceModel.ContextItems = ImportContextItems(isoDevice.DeviceId, "ADAPT_Context_Items:DeviceModel", isoDevice);
 
             //Description
             deviceModel.Description = isoDevice.DeviceDesignator;

--- a/ISOv4Plugin/Mappers/FarmMapper.cs
+++ b/ISOv4Plugin/Mappers/FarmMapper.cs
@@ -90,7 +90,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
 
             //Farm ID
             ImportIDs(farm.Id, isoFarm.FarmId);
-            farm.ContextItems = ImportContextItems(isoFarm.FarmId, "ADAPT_Context_Items:Farm");
+            farm.ContextItems = ImportContextItems(isoFarm.FarmId, "ADAPT_Context_Items:Farm", isoFarm);
 
             //Grower ID
             farm.GrowerId = TaskDataMapper.InstanceIDMap.GetADAPTID(isoFarm.CustomerIdRef);

--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/WorkingDataMapper.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/WorkingDataMapper.cs
@@ -209,6 +209,11 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
         {
             ISODeviceElement isoDeviceElement = TaskDataMapper.DeviceElementHierarchies.GetISODeviceElementFromID(dlv.DeviceElementIdRef);
             List<ISODeviceElement> isoSectionElements = isoDeviceElement.ChildDeviceElements.Where(d => d.DeviceElementType == ISOEnumerations.ISODeviceElementType.Section).ToList();
+            foreach (var subElement in isoDeviceElement.ChildDeviceElements)
+            {
+                //This handles cases where the condensed workstate is reported on a top-level boom with sub-booms in the hierarchy above the sections (e.g., ISO 11783-10:2015(E) Figure F.35)
+                isoSectionElements.AddRange(subElement.ChildDeviceElements.Where(d => d.DeviceElementType == ISOEnumerations.ISODeviceElementType.Section).ToList());
+            }
             //We have some sections in the DDOP
             if (isoSectionElements.Count > 0)
             {

--- a/ISOv4Plugin/Mappers/PartfieldMapper.cs
+++ b/ISOv4Plugin/Mappers/PartfieldMapper.cs
@@ -234,7 +234,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
 
             //Field ID
             ImportIDs(field.Id, isoPartfield.PartfieldID);
-            field.ContextItems = ImportContextItems(isoPartfield.PartfieldID, "ADAPT_Context_Items:Field");
+            field.ContextItems = ImportContextItems(isoPartfield.PartfieldID, "ADAPT_Context_Items:Field", isoPartfield);
 
             //Farm ID
             field.FarmId = TaskDataMapper.InstanceIDMap.GetADAPTID(isoPartfield.FarmIdRef);
@@ -332,7 +332,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
 
             //Cropzone ID
             ImportIDs(cropZone.Id, isoPartfield.PartfieldID);
-            cropZone.ContextItems = ImportContextItems(isoPartfield.PartfieldID, "ADAPT_Context_Items:CropZone");
+            cropZone.ContextItems = ImportContextItems(isoPartfield.PartfieldID, "ADAPT_Context_Items:CropZone", isoPartfield);
 
             //Field ID
             int? fieldID = null;

--- a/ISOv4Plugin/Mappers/PolygonMapper.cs
+++ b/ISOv4Plugin/Mappers/PolygonMapper.cs
@@ -166,7 +166,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
         /// <returns></returns>
         public AttributeShape ImportAttributePolygon(ISOPolygon isoPolygon)
         {
-            Polygon boundaryPolygon = ImportBoundaryPolygon(isoPolygon, false).FirstOrDefault(); 
+            Polygon boundaryPolygon = ImportBoundaryPolygon(isoPolygon, false)?.FirstOrDefault(); 
             if (boundaryPolygon != null && IsFieldAttributeType(isoPolygon))
             {
                 //The data has defined an explicit PLN type that maps to an attribute type

--- a/ISOv4Plugin/Mappers/ProductMapper.cs
+++ b/ISOv4Plugin/Mappers/ProductMapper.cs
@@ -230,7 +230,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             }
 
             //Context Items
-            product.ContextItems = ImportContextItems(isoProduct.ProductId, "ADAPT_Context_Items:Product");
+            product.ContextItems = ImportContextItems(isoProduct.ProductId, "ADAPT_Context_Items:Product", isoProduct);
             ImportPackagedProductClasses(isoProduct, product);
 
 

--- a/ISOv4Plugin/Mappers/TimeLogMapper.cs
+++ b/ISOv4Plugin/Mappers/TimeLogMapper.cs
@@ -383,7 +383,10 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                     operationData.PrescriptionId = prescriptionID;
                     operationData.OperationType = GetOperationTypeFromLoggingDevices(time);
                     operationData.ProductIds = productIDs;
-                    operationData.SpatialRecordCount = isoRecords.Count();
+                    if (!useDeferredExecution)
+                    {
+                        operationData.SpatialRecordCount = isoRecords.Count(); //We will leave this at 0 unless a consumer has overridden deferred execution of spatial data iteration
+                    }
                     operationDatas.Add(operationData);
                 }
 
@@ -539,7 +542,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                                         nextIndexToRead = orderedDLVIndicesToRead.FirstOrDefault(x => x >= dlvIndex); //This returns 0 by default which cannot be less than dlvIndex so we will skip values until the next record if 0.
                                         readIndex = orderedDLVIndicesToRead.IndexOf(nextIndexToRead);
                                     }
-                                    if (dlvIndex == nextIndexToRead)
+                                    if (dlvIndex == nextIndexToRead && orderedDLVIndicesToRead.Contains(dlvIndex))
                                     {
                                         //A desired DLV is reported here
                                         int value = ReadInt32(null, true, binaryReader).GetValueOrDefault();

--- a/ISOv4Plugin/Mappers/UniqueIdMapper.cs
+++ b/ISOv4Plugin/Mappers/UniqueIdMapper.cs
@@ -194,12 +194,34 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
         }
 
         /// <summary>
+        /// Creates ContextItems out of any proprietary attributes
+        /// </summary>
+        /// <param name="element"></param>
+        /// <returns></returns>
+        public List<ContextItem> ImportContextItemsFromProprietaryAttributes(ISOElement element)
+        {
+            List<ContextItem> output = new List<ContextItem>();
+            if (element.ProprietarySchemaExtensions != null)
+            {
+                foreach (string key in element.ProprietarySchemaExtensions.Keys)
+                {
+                    output.Add(new ContextItem
+                    {
+                        Code = string.Concat("Pr_", key), //Recommended ContextItem practice is to prefix any items with Pr_ which are not intended to be common industry vocabulary
+                        Value = element.ProprietarySchemaExtensions[key]
+                    });
+                }
+            }
+            return output;
+        }
+
+        /// <summary>
         /// Returns a list of ContextItems from the LinkGroup matching the object ID
         /// </summary>
         /// <param name="isoObjectIdRef"></param>
         /// <param name="linkGroupDescription">If supplied, the link grup description must match</param>
         /// <returns></returns>
-        public List<ContextItem> ImportContextItems(string isoObjectIdRef, string linkGroupDescription)
+        public List<ContextItem> ImportContextItemsFromLinkList(string isoObjectIdRef, string linkGroupDescription)
         {
             List<ContextItem> outputItems = new List<ContextItem>();
             if (LinkList != null)

--- a/ISOv4Plugin/Mappers/WorkerMapper.cs
+++ b/ISOv4Plugin/Mappers/WorkerMapper.cs
@@ -110,7 +110,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
 
             //Worker ID
             ImportIDs(worker.Id, isoWorker.WorkerId);
-            worker.ContextItems = ImportContextItems(isoWorker.WorkerId, null);
+            worker.ContextItems = ImportContextItems(isoWorker.WorkerId, null, isoWorker);
 
             //Worker name
             worker.LastName = isoWorker.WorkerLastName;


### PR DESCRIPTION
…a (#164)

* Fixing Count() invocation that will unnecessarily iterate spatial data

* Reverting earlier cleanup that introduced new issues with composite units

* Fixing null reference exception in reading non-boundary polygons, fixing issue with 0 DLVIndex in reading implement geometries from binary, and allowing for CondensedWorkstate DDIs logged on grandparent of section device elements.

* Populating proprietary schema extensions into ContextItems on import