### PR TITLE
Private attributes and multi-file TLG

### DIFF
--- a/ISOv4Plugin/ExtensionMethods/ExtensionMethods.cs
+++ b/ISOv4Plugin/ExtensionMethods/ExtensionMethods.cs
@@ -281,5 +281,16 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ExtensionMethods
             }
             return new List<string>();
         }
+
+        /// <summary>
+        /// Case-insensitive comparison of two strings
+        /// </summary>
+        /// <param name="value1"></param>
+        /// <param name="value2"></param>
+        /// <returns></returns>
+        public static bool EqualsIgnoreCase(this string value1, string value2)
+        {
+            return string.Equals(value1, value2, StringComparison.OrdinalIgnoreCase);
+        }
     }
 }

--- a/ISOv4Plugin/ExtensionMethods/ExtensionMethods.cs
+++ b/ISOv4Plugin/ExtensionMethods/ExtensionMethods.cs
@@ -2,21 +2,20 @@
  * ISO standards can be purchased through the ANSI webstore at https://webstore.ansi.org
 */
 
+using System;
 using System.Collections.Generic;
-using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using AgGateway.ADAPT.ApplicationDataModel.Common;
 using AgGateway.ADAPT.ApplicationDataModel.Equipment;
 using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
 using AgGateway.ADAPT.ApplicationDataModel.Representations;
-using AgGateway.ADAPT.ISOv4Plugin.ObjectModel;
+using AgGateway.ADAPT.ISOv4Plugin.ISOModels;
 using AgGateway.ADAPT.ISOv4Plugin.Mappers;
-using System;
-using System.IO;
+using AgGateway.ADAPT.ISOv4Plugin.ObjectModel;
 using AgGateway.ADAPT.ISOv4Plugin.Representation;
 using RepresentationUnitSystem = AgGateway.ADAPT.Representation.UnitSystem;
-using AgGateway.ADAPT.ISOv4Plugin.ISOModels;
 
 
 namespace AgGateway.ADAPT.ISOv4Plugin.ExtensionMethods
@@ -291,6 +290,51 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ExtensionMethods
         public static bool EqualsIgnoreCase(this string value1, string value2)
         {
             return string.Equals(value1, value2, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Returns an earlier value of two DateTime objects
+        /// </summary>
+        /// <param name="time1"></param>
+        /// <param name="time2"></param>
+        /// <returns></returns>
+        public static DateTime? Min(this DateTime? time1, DateTime? time2)
+        {
+            if (time1.HasValue && time2.HasValue)
+            {
+                return time1.Value <= time2.Value ? time1: time2;
+            }
+            return time1.HasValue ? time1 : time2;
+        }
+
+        /// <summary>
+        /// Returns a later value of two DateTime objects
+        /// </summary>
+        /// <param name="time1"></param>
+        /// <param name="time2"></param>
+        /// <returns></returns>
+        public static DateTime? Max(this DateTime? time1, DateTime? time2)
+        {
+            if (time1.HasValue && time2.HasValue)
+            {
+                return time1.Value >= time2.Value ? time1 : time2;
+            }
+            return time1.HasValue ? time1 : time2;
+        }
+
+        /// <summary>
+        /// Max of two integer values
+        /// </summary>
+        /// <param name="value1"></param>
+        /// <param name="value2"></param>
+        /// <returns></returns>
+        public static uint? Max(this uint? value1, uint? value2)
+        {
+            if (value1.HasValue && value1.HasValue)
+            {
+                return value1 >= value2 ? value1 : value2;
+            }
+            return value1.HasValue ? value1 : value2;
         }
     }
 }

--- a/ISOv4Plugin/ISOModels/ISOTime.cs
+++ b/ISOv4Plugin/ISOModels/ISOTime.cs
@@ -2,13 +2,12 @@
  * ISO standards can be purchased through the ANSI webstore at https://webstore.ansi.org
 */
 
-using AgGateway.ADAPT.ApplicationDataModel.ADM;
-using AgGateway.ADAPT.ISOv4Plugin.ExtensionMethods;
-using AgGateway.ADAPT.ISOv4Plugin.ISOEnumerations;
-using AgGateway.ADAPT.ISOv4Plugin.ObjectModel;
 using System;
 using System.Collections.Generic;
 using System.Xml;
+using AgGateway.ADAPT.ApplicationDataModel.ADM;
+using AgGateway.ADAPT.ISOv4Plugin.ExtensionMethods;
+using AgGateway.ADAPT.ISOv4Plugin.ISOEnumerations;
 
 namespace AgGateway.ADAPT.ISOv4Plugin.ISOModels
 {
@@ -104,6 +103,38 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ISOModels
             Positions.ForEach(i => i.Validate(errors));
             DataLogValues.ForEach(i => i.Validate(errors));
             return errors;
+        }
+
+        public static ISOTime Merge(ISOTime time, ISOTime otherTime)
+        {
+            if (time == null)
+            {
+                return otherTime;
+            }
+            if (otherTime == null)
+            {
+                return time;
+            }
+
+            ISOTime result = new ISOTime
+            {
+                // Pick earlier date
+                Start = time.Start.Min(otherTime.Start),
+                // Pick later date
+                Stop = time.Stop.Max(otherTime.Stop),
+                // Pick max from both since they most likely overlap
+                Duration = time.Duration.Max(otherTime.Duration),
+                Type = time.Type == 0 ? otherTime.Type : time.Type,
+                HasStart = time.HasStart || otherTime.HasStart,
+                HasStop = time.HasStop || otherTime.HasStop,
+                HasDuration = time.HasDuration || otherTime.HasDuration,
+                HasType = time.HasType || otherTime.HasType
+            };
+
+            result.DataLogValues.AddRange(time.DataLogValues);
+            result.DataLogValues.AddRange(otherTime.DataLogValues);
+
+            return result;
         }
     }
 }

--- a/ISOv4Plugin/Mappers/Factories/TimeLogMapperFactory.cs
+++ b/ISOv4Plugin/Mappers/Factories/TimeLogMapperFactory.cs
@@ -1,0 +1,171 @@
+/*
+ * ISO standards can be purchased through the ANSI webstore at https://webstore.ansi.org
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
+using AgGateway.ADAPT.ISOv4Plugin.ISOModels;
+
+namespace AgGateway.ADAPT.ISOv4Plugin.Mappers.Factories
+{
+    /// <summary>
+    /// Factory class to help process ISOTimeLog data
+    /// </summary>
+    public class TimeLogMapperFactory
+    {
+        private readonly TimeLogMapper _timeLogMapper;
+        private readonly MultiFileTimeLogMapper _multiFileTimeLogMapper;
+        private readonly TaskDataMapper _taskDataMapper;
+
+        // A wrapper class to hold together ISOTimeLog and included ISODataLogValues.
+        // This avoids multiple calls to ISOTimeLog.GetTimeElement() which performs xml parsing on each call.
+        private class TimeLogWrapper
+        {
+            public ISOTimeLog ISOTimeLog { get; set; }
+            public List<ISODataLogValue> DataLogValues { get; set; }
+        }
+
+        // Class representing a group of TimeLogWrapper objects that should be processed together
+        private class TimeLogWrapperGroup : List<TimeLogWrapper>
+        {
+            public TimeLogWrapperGroup()
+            {
+                KeepAsGroup = false;
+            }
+
+            public bool KeepAsGroup { get; set; }
+        }
+
+        // Class representing a group of ISOTimeLog objects that will be processed as single entity
+        private class TimeLogGroup : List<ISOTimeLog>
+        {
+            public TimeLogGroup(IEnumerable<ISOTimeLog> collection): base(collection) { }
+        }
+
+        public TimeLogMapperFactory(TaskDataMapper taskDataMapper)
+        {
+            _taskDataMapper = taskDataMapper;
+            _timeLogMapper = new TimeLogMapper(taskDataMapper);
+            _multiFileTimeLogMapper = new MultiFileTimeLogMapper(taskDataMapper);
+        }
+
+        public IEnumerable<OperationData> ImportTimeLogs(ISOTask loggedTask, int? prescriptionID)
+        {
+            var timeLogGroups = GetTimeLogGroups(loggedTask);
+
+            var opearationDats = new List<OperationData>();
+            foreach (var timeLogGroup in timeLogGroups)
+            {
+                opearationDats.AddRange(timeLogGroup.Count > 1
+                    ? _multiFileTimeLogMapper.ImportTimeLogs(loggedTask, timeLogGroup, prescriptionID)
+                    : _timeLogMapper.ImportTimeLogs(loggedTask, timeLogGroup, prescriptionID));
+            }
+            return opearationDats;
+        }
+
+        public IEnumerable<ISOTimeLog> ExportTimeLogs(IEnumerable<OperationData> operationDatas, string dataPath)
+        {
+            return _timeLogMapper.ExportTimeLogs(operationDatas, dataPath);
+        }
+
+
+        private List<TimeLogGroup> GetTimeLogGroups(ISOTask loggedTask)
+        {
+            var dataPath = _timeLogMapper.TaskDataPath;
+
+            var timeLogGroups = GroupByDataLogValueCount(loggedTask, dataPath);
+            timeLogGroups = HandleRollOverScenario(timeLogGroups);
+            timeLogGroups = HandleDuplicateDataLogValues(timeLogGroups);
+
+            return timeLogGroups.Select(x => new TimeLogGroup(x.Select(y => y.ISOTimeLog).ToList())).ToList();
+        }
+
+        private List<TimeLogWrapperGroup> HandleDuplicateDataLogValues(List<TimeLogWrapperGroup> timeLogGroups)
+        {
+            var result = new List<TimeLogWrapperGroup> ();
+            // Check if all DataLogValues are referencing unique combination of DET/DDI.
+            // Exclude PGN-based DLVs as they are not unique.
+            foreach (var timeLogGroup in timeLogGroups)
+            {
+                var duplicatesByElementAndDDI = timeLogGroup.SelectMany(x => x.DataLogValues)
+                    .Where(x => x.DataLogPGN == null)
+                    .GroupBy(x => new { x.DeviceElementIdRef, x.ProcessDataDDI })
+                    .Where(x => x.Count() > 1);
+                if (!timeLogGroup.KeepAsGroup && duplicatesByElementAndDDI.Any())
+                {
+                    // Some DataLogValues are referencing same combination of DET/DDI.
+                    // Split them into separate groups
+                    result.AddRange(timeLogGroup.Select(x => new TimeLogWrapperGroup { x }));
+                }
+                else
+                {
+                    result.Add(timeLogGroup);
+                }
+            }
+            return result;
+        }
+
+        private List<TimeLogWrapperGroup> HandleRollOverScenario(List<TimeLogWrapperGroup> timeLogGroups)
+        {
+            // Initial TLG files with less than 255 DLVs could be changed
+            // by appending more DLVs to then in the process. The other file where these DLVS
+            // are coming from is no longer written in.
+            foreach (var timeLogGroup in timeLogGroups)
+            {
+                // Unique device element ids from all duplicate DLVs
+                var duplicateDeviceElementIds = timeLogGroup.SelectMany(y => y.DataLogValues)
+                    .Where(x => x.DataLogPGN == null)
+                    .GroupBy(x => new { x.DeviceElementIdRef, x.ProcessDataDDI })
+                    .Where(x => x.Count() > 1)
+                    .Select(x => x.Key.DeviceElementIdRef)
+                    .Distinct()
+                    .ToList();
+                if (duplicateDeviceElementIds.Count <= 0)
+                {
+                    continue;
+                }
+
+                // Count how many TLGs have 255 DLVs
+                var timeLogs = timeLogGroup.Where(x => x.DataLogValues.Any(y => duplicateDeviceElementIds.Contains(y.DeviceElementIdRef)))
+                    .Where(x => x.DataLogValues.Count == 255)
+                    .ToList();
+
+                // Multiple TLGs with 255 DLVs in them. Most likely a roll-over scenario
+                if (timeLogs.Count > 1)
+                {
+                    // Keep them as a single group
+                    timeLogGroup.KeepAsGroup = true;
+                }
+            }
+
+            return timeLogGroups;
+        }
+
+        private List<TimeLogWrapperGroup> GroupByDataLogValueCount(ISOTask loggedTask, string dataPath)
+        {
+            // All consequent time logs with 255 DLVs are kept together as a group.
+            var timeLogGroups = new List<TimeLogWrapperGroup>();
+            var logGroup = new TimeLogWrapperGroup();
+            foreach (var timeLog in loggedTask.TimeLogs)
+            {
+                ISOTime templateTime = timeLog.GetTimeElement(dataPath);
+                logGroup.Add(new TimeLogWrapper { DataLogValues = templateTime.DataLogValues, ISOTimeLog = timeLog });
+                // A time log with less than 255 DLVs found. Add it to current group
+                // and start a new one.
+                if (templateTime.DataLogValues.Count < 255)
+                {
+                    timeLogGroups.Add(logGroup);
+                    logGroup = new TimeLogWrapperGroup();
+                }
+            }
+            // Add remaning log group
+            if (logGroup.Count > 0)
+            {
+                timeLogGroups.Add(logGroup);
+            }
+            return timeLogGroups;
+        }
+    }
+}

--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/SpatialRecordMapper.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/SpatialRecordMapper.cs
@@ -89,9 +89,10 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
 
         private void SetEnumeratedMeterValue(ISOSpatialRow isoSpatialRow, EnumeratedWorkingData meter, SpatialRecord spatialRecord)
         {
+            var isoDataLogValue = _workingDataMapper.DataLogValuesByWorkingDataID[meter.Id.ReferenceId];
             var isoValue = isoSpatialRow.SpatialValues.FirstOrDefault(v =>
-                    v.DataLogValue.DeviceElementIdRef == _workingDataMapper.DataLogValuesByWorkingDataID[meter.Id.ReferenceId].DeviceElementIdRef &&
-                    v.DataLogValue.ProcessDataDDI == _workingDataMapper.DataLogValuesByWorkingDataID[meter.Id.ReferenceId].ProcessDataDDI);
+                    v.DataLogValue.DeviceElementIdRef == isoDataLogValue.DeviceElementIdRef &&
+                    v.DataLogValue.ProcessDataDDI == isoDataLogValue.ProcessDataDDI);
             if (isoValue != null)
             {
                 var isoEnumeratedMeter = meter as ISOEnumeratedMeter;
@@ -108,11 +109,15 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
 
         private void SetNumericMeterValue(ISOSpatialRow isoSpatialRow, NumericWorkingData meter, SpatialRecord spatialRecord, Dictionary<string, List<ISOProductAllocation>> productAllocations)
         {
-            var isoValue = isoSpatialRow.SpatialValues.FirstOrDefault(v =>
+            var dataLogValue = _workingDataMapper.DataLogValuesByWorkingDataID.ContainsKey(meter.Id.ReferenceId)
+                ? _workingDataMapper.DataLogValuesByWorkingDataID[meter.Id.ReferenceId]
+                : null;
+            var isoValue = dataLogValue != null
+                           ? isoSpatialRow.SpatialValues.FirstOrDefault(v =>
                                 v.DataLogValue.ProcessDataDDI != "DFFE" &&
-                                _workingDataMapper.DataLogValuesByWorkingDataID.ContainsKey(meter.Id.ReferenceId) &&
-                                v.DataLogValue.DeviceElementIdRef == _workingDataMapper.DataLogValuesByWorkingDataID[meter.Id.ReferenceId].DeviceElementIdRef &&
-                                v.DataLogValue.ProcessDataDDI == _workingDataMapper.DataLogValuesByWorkingDataID[meter.Id.ReferenceId].ProcessDataDDI);
+                                v.DataLogValue.DeviceElementIdRef == dataLogValue.DeviceElementIdRef &&
+                                v.DataLogValue.ProcessDataDDI == dataLogValue.ProcessDataDDI)
+                           : null;
 
 
             if (isoValue != null)

--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/SpatialRecordMapper.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/SpatialRecordMapper.cs
@@ -142,25 +142,26 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                 string detID = _workingDataMapper.ISODeviceElementIDsByWorkingDataID[meter.Id.ReferenceId];
                 if (productAllocations.ContainsKey(detID)) //The DeviceElement for this meter exists in the list of allocations
                 {
+                    var productAllocationsForDeviceElement = productAllocations[detID];
                     double numericValue = 0d;
-                    if (productAllocations[detID].Count == 1 || TimeLogMapper.GetDistinctProductIDs(_taskDataMapper, productAllocations).Count == 1)
+                    if (productAllocationsForDeviceElement.Count == 1 || TimeLogMapper.GetDistinctProductIDs(_taskDataMapper, productAllocations).Count == 1)
                     {
                         //This product is consistent throughout the task on this device element
-                        int? adaptProductID = _taskDataMapper.InstanceIDMap.GetADAPTID(productAllocations[detID].Single().ProductIdRef);
+                        int? adaptProductID = _taskDataMapper.InstanceIDMap.GetADAPTID(productAllocationsForDeviceElement.Single().ProductIdRef);
                         numericValue = adaptProductID.HasValue ? adaptProductID.Value : 0d;
 
                     }
-                    else if (productAllocations[detID].Count > 1)
+                    else if (productAllocationsForDeviceElement.Count > 1)
                     {
                         //There are multiple product allocations for the device element
                         //Find the product allocation that governs this timestamp
-                        ISOProductAllocation relevantPan = productAllocations[detID].FirstOrDefault(p => Offset(p.AllocationStamp.Start) <= spatialRecord.Timestamp &&
+                        ISOProductAllocation relevantPan = productAllocationsForDeviceElement.FirstOrDefault(p => Offset(p.AllocationStamp.Start) <= spatialRecord.Timestamp &&
                                                                                                          (p.AllocationStamp.Stop == null ||
                                                                                                           Offset(p.AllocationStamp.Stop) >= spatialRecord.Timestamp));
                         if (relevantPan == null)
                         {
                             //We couldn't correlate strictly based on time.  Check for a more general match on date alone before returning null.
-                            var pansMatchingDate = productAllocations[detID].Where(p => p.AllocationStamp.Start?.Date == p.AllocationStamp.Stop?.Date &&
+                            var pansMatchingDate = productAllocationsForDeviceElement.Where(p => p.AllocationStamp.Start?.Date == p.AllocationStamp.Stop?.Date &&
                                                                                p.AllocationStamp.Start?.Date == spatialRecord.Timestamp.Date);
                             if (pansMatchingDate.Count() == 1)
                             {

--- a/ISOv4Plugin/Mappers/Manufacturers/CNH.cs
+++ b/ISOv4Plugin/Mappers/Manufacturers/CNH.cs
@@ -88,6 +88,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers.Manufacturers
         };
         private const string CropTypeAttributeName = "P094_Crop_Type";
         private const string ProductFormAttributeName = "P094_Product_Form";
+        private const string ProductUsageAttributeName = "P094_Product_Usage";
 
         private string GetAttributeByName(ISOElement isoElement, string name)
         {
@@ -159,6 +160,38 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers.Manufacturers
                 default:
                     return null;
             }
+        }
+
+        public CategoryEnum? GetProductCategory(ISOProduct isoProduct)
+        {
+            var productUsageAsString = GetAttributeByName(isoProduct, ProductUsageAttributeName);
+
+            if (string.IsNullOrEmpty(productUsageAsString) ||
+               !int.TryParse(productUsageAsString, NumberStyles.Integer, CultureInfo.InvariantCulture, out int productUsage))
+            {
+                return null;
+            }
+
+            switch (productUsage)
+            {
+                case 0: // Generic
+                    return CategoryEnum.Unknown;
+                case 1: // Carrier
+                    return CategoryEnum.Carrier;
+                case 2: // Fertilizer
+                    return CategoryEnum.Fertilizer;
+                case 3: // Herbicide
+                    return CategoryEnum.Herbicide;
+                case 4: // Fungicide
+                    return CategoryEnum.Fungicide;
+                case 5: // Insecticide
+                    return CategoryEnum.Insecticide;
+                case 6: // Pesticide
+                    return CategoryEnum.Pesticide;
+                case 7: // Seed/Plant
+                    return CategoryEnum.Variety;
+            }
+            return null;
         }
     }
 }

--- a/ISOv4Plugin/Mappers/Manufacturers/CNH.cs
+++ b/ISOv4Plugin/Mappers/Manufacturers/CNH.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+using System.Globalization;
+using AgGateway.ADAPT.ISOv4Plugin.ISOModels;
+
+namespace AgGateway.ADAPT.ISOv4Plugin.Mappers.Manufacturers
+{
+    internal class CNH : IManufacturer
+    {
+        private Dictionary<int, string> _supportedCrops = new Dictionary<int, string>
+        {
+            {0, "Beans-Soybean"},
+            {1, "Corn"},
+            {2, "Wheat"},
+            {3, "Oats"},
+            {4, "Rye-Winter"},
+            {5, "Barley-Winter"},
+            {6, "Sorghum"},
+            {7, "Popcorn"},
+            {8, "Beans-Edible"},
+            {9, "Corn2" },
+            {10, "Canola"},
+            {11, "Rice"},
+            {12, "Sunflower"},
+            {13, "Maize_CCM"},
+            {14, "Maize"},
+            {15, "Grains-Other"},
+            {16, "Alfalfa"},
+            {17, "Barley-Fall"},
+            {18, "Barley-Spring"},
+            {19, "Beans-Adzuki"},
+            {20, "Beans-Faber"},
+            {21, "Beans-Field"},
+            {22, "Buckwheat"},
+            {23, "Borage"},
+            {24, "Clover-Crimson"},
+            {25, "Clover-White"},
+            {26, "Flax " },
+            {27, "Grass-Bent"},
+            {28, "Grass-Blue"},
+            {29, "Grass-Red_Fescue"},
+            {30, "Grass-Orchard"},
+            {31, "Lentils"},
+            {32, "Grass"},
+            {33, "Ryegrass-Annual"},
+            {34, "Lupins"},
+            {35, "Meadowfoam"},
+            {36, "Millet"},
+            {37, "Mustard"},
+            {38, "Peanuts"},
+            {39, "Peas-Chick"},
+            {40, "Peas-Field"},
+            {41, "Rape_Seed"},
+            {42, "Rice-Wild"},
+            {43, "Ryegrass-Perennial"},
+            {44, "Rye-Spring"},
+            {45, "Safflower"},
+            {46, "Triticale"},
+            {47, "Wheat-Durum"},
+            {48, "Wheat-Spring"},
+            {49, "Wheat-Winter"},
+            {50, "ELS"},
+            {51, "Upland_Cotton"},
+            {52, "Cotton_3" },
+            {53, "Cotton_4" },
+            {54, "None"},
+            {55, "Beans-Broad"},
+            {56, "Berries"},
+            {57, "Bulbs"},
+            {58, "Cabbage"},
+            {59, "Cotton"},
+            {60, "Fruit-Misc"},
+            {61, "Grapes"},
+            {62, "Hay_&_Forage"},
+            {63, "Hemp"},
+            {64, "Horseradish"},
+            {65, "Lettuce"},
+            {66, "Melons"},
+            {67, "Nuts"},
+            {68, "Onions"},
+            {69, "Peas-Pigeon"},
+            {70, "Potatoes"},
+            {71, "Spices"},
+            {72, "Sugar_Beets"},
+            {73, "Sugarcane"},
+            {74, "Tomatoes"},
+            {75, "Vegetable-Misc"}
+        };
+        private const string CropTypeAttributeName = "P094_Crop_Type";
+
+        public string GetCropName(ISOElement isoElement)
+        {
+            Dictionary<string, string> schemaProperties = isoElement?.ProprietarySchemaExtensions;
+            if (schemaProperties == null || schemaProperties.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            if (!schemaProperties.TryGetValue(CropTypeAttributeName, out string cropTypeAsString) ||
+                !int.TryParse(cropTypeAsString, NumberStyles.Integer, CultureInfo.InvariantCulture, out int cropType) ||
+                !_supportedCrops.TryGetValue(cropType, out string cropName))
+            {
+                return string.Empty;
+            }
+
+            return cropName;
+        }
+    }
+}

--- a/ISOv4Plugin/Mappers/Manufacturers/CNH.cs
+++ b/ISOv4Plugin/Mappers/Manufacturers/CNH.cs
@@ -89,6 +89,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers.Manufacturers
         private const string CropTypeAttributeName = "P094_Crop_Type";
         private const string ProductFormAttributeName = "P094_Product_Form";
         private const string ProductUsageAttributeName = "P094_Product_Usage";
+        private const string ProductManufacturer = "P094_Product_Manufacturer";
 
         private string GetAttributeByName(ISOElement isoElement, string name)
         {
@@ -192,6 +193,18 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers.Manufacturers
                     return CategoryEnum.Variety;
             }
             return null;
+        }
+
+        public string GetProductManufacturer(ISOProduct isoProduct)
+        {
+            var productManufacturer = GetAttributeByName(isoProduct, ProductManufacturer);
+
+            if (string.IsNullOrEmpty(productManufacturer))
+            {
+                return string.Empty;
+            }
+
+            return productManufacturer;
         }
     }
 }

--- a/ISOv4Plugin/Mappers/Manufacturers/ManufacturerFactory.cs
+++ b/ISOv4Plugin/Mappers/Manufacturers/ManufacturerFactory.cs
@@ -10,6 +10,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers.Manufacturers
         ProductFormEnum? GetProductForm(ISOProduct isoProduct);
         ProductTypeEnum? GetProductType(ISOProduct isoProduct);
         CategoryEnum? GetProductCategory(ISOProduct isoProduct);
+        string GetProductManufacturer(ISOProduct isoProduct);
     }
 
     internal static class ManufacturerFactory

--- a/ISOv4Plugin/Mappers/Manufacturers/ManufacturerFactory.cs
+++ b/ISOv4Plugin/Mappers/Manufacturers/ManufacturerFactory.cs
@@ -1,3 +1,4 @@
+using AgGateway.ADAPT.ApplicationDataModel.Products;
 using AgGateway.ADAPT.ISOv4Plugin.ExtensionMethods;
 using AgGateway.ADAPT.ISOv4Plugin.ISOModels;
 
@@ -6,6 +7,8 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers.Manufacturers
     internal interface IManufacturer
     {
         string GetCropName(ISOElement isoElement);
+        ProductFormEnum? GetProductForm(ISOProduct isoProduct);
+        ProductTypeEnum? GetProductType(ISOProduct isoProduct);
     }
 
     internal static class ManufacturerFactory

--- a/ISOv4Plugin/Mappers/Manufacturers/ManufacturerFactory.cs
+++ b/ISOv4Plugin/Mappers/Manufacturers/ManufacturerFactory.cs
@@ -1,0 +1,24 @@
+using AgGateway.ADAPT.ISOv4Plugin.ExtensionMethods;
+using AgGateway.ADAPT.ISOv4Plugin.ISOModels;
+
+namespace AgGateway.ADAPT.ISOv4Plugin.Mappers.Manufacturers
+{
+    internal interface IManufacturer
+    {
+        string GetCropName(ISOElement isoElement);
+    }
+
+    internal static class ManufacturerFactory
+    {
+        private const string CNHManufacturer = "CNH Industrial N.V.";
+
+        public static IManufacturer GetManufacturer(TaskDataMapper taskDataMapper)
+        {
+            if (taskDataMapper.ISOTaskData.TaskControllerManufacturer.EqualsIgnoreCase(CNHManufacturer))
+            {
+                return new CNH();
+            }
+            return null;
+        }
+    }
+}

--- a/ISOv4Plugin/Mappers/Manufacturers/ManufacturerFactory.cs
+++ b/ISOv4Plugin/Mappers/Manufacturers/ManufacturerFactory.cs
@@ -9,6 +9,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers.Manufacturers
         string GetCropName(ISOElement isoElement);
         ProductFormEnum? GetProductForm(ISOProduct isoProduct);
         ProductTypeEnum? GetProductType(ISOProduct isoProduct);
+        CategoryEnum? GetProductCategory(ISOProduct isoProduct);
     }
 
     internal static class ManufacturerFactory

--- a/ISOv4Plugin/Mappers/MultiFileTimeLogMapper.cs
+++ b/ISOv4Plugin/Mappers/MultiFileTimeLogMapper.cs
@@ -1,0 +1,147 @@
+/*
+ * ISO standards can be purchased through the ANSI webstore at https://webstore.ansi.org
+*/
+
+using System.Collections.Generic;
+using System.Linq;
+using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
+using AgGateway.ADAPT.ISOv4Plugin.ISOModels;
+using AgGateway.ADAPT.ISOv4Plugin.ObjectModel;
+
+namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
+{
+    /// <summary>
+    /// A TimeLogMapper class with support for data split between two or more ISO TLG files.
+    /// </summary>
+    internal class MultiFileTimeLogMapper : TimeLogMapper, ITimeLogMapper
+    {
+        private ISOTime _combinedTime;
+        private IEnumerable<ISOTimeLog> _timeLogs;
+
+        // Helper class to keep track of individual TLG files and current record from each
+        private class BinaryReaderHelper
+        {
+            public IEnumerator<ISOSpatialRow> Enumerator { get; set; }
+            public ISOSpatialRow CurrentRecord { get; set; }
+        }
+
+        internal MultiFileTimeLogMapper(TaskDataMapper taskDataMapper)
+            : base(taskDataMapper)
+        {
+        }
+
+        #region Import
+
+        public override IEnumerable<OperationData> ImportTimeLogs(ISOTask loggedTask, IEnumerable<ISOTimeLog> timeLogs, int? prescriptionID)
+        {
+            _timeLogs = timeLogs;
+            // Combine ISOTime elements from each TimeLog into one.
+            _combinedTime = CreateCombinedTime();
+            // Read data from all timelogs as if it was a single file.
+            // Pass first available TimeLog to avoid breaking base class.
+            return ImportTimeLog(loggedTask, timeLogs.First(), prescriptionID);
+        }
+
+        protected override IEnumerable<ISOSpatialRow> ReadTimeLog(ISOTimeLog _timeLog, string _dataPath)
+        {
+            List<BinaryReaderHelper> readers = new List<BinaryReaderHelper>();
+            try
+            {
+                // Obtain binary readers for each time log
+                foreach (var timeLog in _timeLogs)
+                {
+                    var reader = base.ReadTimeLog(timeLog, TaskDataPath);
+                    if (reader != null)
+                    {
+                        readers.Add(new BinaryReaderHelper
+                        {
+                            Enumerator = reader.GetEnumerator()
+                        });
+                    }
+                }
+
+                return ReadFromBinaryReaders(readers);
+            }
+            finally
+            {
+                // Clean up readers
+                foreach (var reader in readers)
+                {
+                    reader.Enumerator?.Dispose();
+                }
+            }
+        }
+
+        private IEnumerable<ISOSpatialRow> ReadFromBinaryReaders(List<BinaryReaderHelper> readers)
+        {
+            // Below alogrithm is using queues for each binary file and matching records on TimeStart/Position.
+            // At start of each iteration a single record is read from binary file into queue.
+            // Records with earliest TimeStart are merged together and removed from each file queue.
+            while (true)
+            {
+                // Read next record from each time log
+                foreach (var reader in readers)
+                {
+                    if (reader.CurrentRecord == null)
+                    {
+                        reader.CurrentRecord = reader.Enumerator.MoveNext() ? reader.Enumerator.Current : null;
+                    }
+                }
+
+                // Only get readers which still have records;
+                var readersWithData = readers.Where(x => x.CurrentRecord != null).ToList();
+                if (readersWithData.Count == 0)
+                {
+                    // No more records in each file. Stop processing.
+                    break;
+                }
+
+                // Group records by TimeStart and East/North position, and then grab ones with earliest TimeStart.
+                // This leads to processing earliest records from any file first and keeping other records untouched.
+                // They will be processed in the next loop iteration along with any records read from already processed files.
+                var candidates = readersWithData.GroupBy(x => new { x.CurrentRecord.TimeStart, x.CurrentRecord.EastPosition, x.CurrentRecord.NorthPosition })
+                    .OrderBy(x => x.Key.TimeStart)
+                    .First().ToList();
+
+                // Merge data from all candidates into first record
+                ISOSpatialRow result = null;
+                foreach (var candidate in candidates)
+                {
+                    result = result == null ? candidate.CurrentRecord : result.Merge(candidate.CurrentRecord);
+                    // Clear current record to force reading next one
+                    candidate.CurrentRecord = null;
+                }
+
+                yield return result;
+            }
+        }
+
+        protected override ISOTime GetTimeElementFromTimeLog(ISOTimeLog isoTimeLog)
+        {
+            // Always return a combined ISOTime record.
+            return _combinedTime;
+        }
+
+        private ISOTime CreateCombinedTime()
+        {
+            ISOTime result = null;
+            foreach (var timeLog in _timeLogs)
+            {
+                var time = timeLog.GetTimeElement(TaskDataPath);
+                result = ISOTime.Merge(result, time);
+            }
+
+            var duplicateDataLogValues = result.DataLogValues
+                .Where(x => x.DataLogPGN == null)
+                .GroupBy(x => new { x.DeviceElementIdRef, x.ProcessDataDDI })
+                .Where(x => x.Count() > 1)
+                .SelectMany(x => x.Skip(1))
+                .ToList();
+            duplicateDataLogValues.ForEach(x => result.DataLogValues.Remove(x));
+
+            return result;
+        }
+
+        #endregion Import
+    }
+}

--- a/ISOv4Plugin/Mappers/ProductMapper.cs
+++ b/ISOv4Plugin/Mappers/ProductMapper.cs
@@ -247,7 +247,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             product.Description = isoProduct.ProductDesignator;
 
             //Mixes
-            product.ProductComponents = ImportProductComponents(isoProduct, product.Form);
+            product.ProductComponents = ImportProductComponents(isoProduct);
 
             //Total Mix quantity
             if (isoProduct.MixtureRecipeQuantity.HasValue && product is MixProduct mixProduct)
@@ -291,7 +291,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             return manufacturer.Id.ReferenceId;
         }
 
-        private List<ProductComponent> ImportProductComponents(ISOProduct isoProduct, ProductFormEnum productForm)
+        private List<ProductComponent> ImportProductComponents(ISOProduct isoProduct)
         {
             if (!isoProduct.ProductRelations.Any())
             {
@@ -311,9 +311,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                     Product adaptProduct = DataModel.Catalog.Products.FirstOrDefault(i => i.Id.FindIsoId() == isoComponent.ProductId);
                     if (adaptProduct == null)
                     {
-                        adaptProduct = new GenericProduct();
-                        adaptProduct.Description = isoComponent.ProductDesignator;
-                        DataModel.Catalog.Products.Add(adaptProduct);
+                        adaptProduct = ImportProduct(isoComponent);
                     }
 
                     //Create a component for this ingredient
@@ -324,7 +322,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                         IsCarrier = adaptProduct.Category == CategoryEnum.Carrier
                     };
 
-                    var quantityDDI = GetQuantityDDI(isoComponent.QuantityDDI, productForm);
+                    var quantityDDI = GetQuantityDDI(isoComponent.QuantityDDI, adaptProduct.Form);
                     if (!string.IsNullOrEmpty(quantityDDI))
                     {
                         component.Quantity = prn.QuantityValue.AsNumericRepresentationValue(quantityDDI, RepresentationMapper);

--- a/ISOv4Plugin/Mappers/ProductMapper.cs
+++ b/ISOv4Plugin/Mappers/ProductMapper.cs
@@ -217,6 +217,9 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                 TaskDataMapper.InstanceIDMap.ReplaceISOID(product.Id.ReferenceId, isoProduct.ProductId);
             }
 
+            // ProductForm
+            product.Form = _manufacturer?.GetProductForm(isoProduct) ?? product.Form;
+
             //Context Items
             product.ContextItems = ImportContextItems(isoProduct.ProductId, "ADAPT_Context_Items:Product", isoProduct);
             ImportPackagedProductClasses(isoProduct, product);
@@ -322,7 +325,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                     break;
                 default:
                     product = new GenericProduct();
-                    product.ProductType = ProductTypeEnum.Generic;
+                    product.ProductType = _manufacturer?.GetProductType(isoProduct) ?? ProductTypeEnum.Generic;
                     break;
             }
             return product;

--- a/ISOv4Plugin/Mappers/ProductMapper.cs
+++ b/ISOv4Plugin/Mappers/ProductMapper.cs
@@ -11,6 +11,7 @@ using AgGateway.ADAPT.ISOv4Plugin.ISOEnumerations;
 using AgGateway.ADAPT.ApplicationDataModel.Products;
 using AgGateway.ADAPT.ApplicationDataModel.Common;
 using AgGateway.ADAPT.ISOv4Plugin.Mappers.Manufacturers;
+using AgGateway.ADAPT.ApplicationDataModel.Logistics;
 
 namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
 {
@@ -239,6 +240,8 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             product.ContextItems = ImportContextItems(isoProduct.ProductId, "ADAPT_Context_Items:Product", isoProduct);
             ImportPackagedProductClasses(isoProduct, product);
 
+            // Manufacturer
+            product.ManufacturerId = ImportManufacturer(isoProduct);
 
             //Description
             product.Description = isoProduct.ProductDesignator;
@@ -268,6 +271,24 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             }
 
             return product;
+        }
+
+        private int? ImportManufacturer(ISOProduct isoProduct)
+        {
+            var manufacturerName = _manufacturer?.GetProductManufacturer(isoProduct);
+            if (string.IsNullOrWhiteSpace(manufacturerName))
+            {
+                return null;
+            }
+
+            var manufacturer = TaskDataMapper.AdaptDataModel.Catalog.Manufacturers.FirstOrDefault(x => x.Description.EqualsIgnoreCase(manufacturerName));
+            if (manufacturer == null)
+            {
+                manufacturer = new Manufacturer();
+                manufacturer.Description = manufacturerName;
+                TaskDataMapper.AdaptDataModel.Catalog.Manufacturers.Add(manufacturer);
+            }
+            return manufacturer.Id.ReferenceId;
         }
 
         private List<ProductComponent> ImportProductComponents(ISOProduct isoProduct, ProductFormEnum productForm)

--- a/ISOv4Plugin/Mappers/TaskDataMapper.cs
+++ b/ISOv4Plugin/Mappers/TaskDataMapper.cs
@@ -4,21 +4,17 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using AgGateway.ADAPT.ISOv4Plugin.ISOModels;
 using AgGateway.ADAPT.ApplicationDataModel.ADM;
+using AgGateway.ADAPT.ApplicationDataModel.Common;
+using AgGateway.ADAPT.ApplicationDataModel.Documents;
 using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
 using AgGateway.ADAPT.ApplicationDataModel.Logistics;
 using AgGateway.ADAPT.ApplicationDataModel.Products;
-using AgGateway.ADAPT.ApplicationDataModel.Documents;
-using AgGateway.ADAPT.ISOv4Plugin.Representation;
-using AgGateway.ADAPT.ApplicationDataModel.Equipment;
+using AgGateway.ADAPT.ISOv4Plugin.ISOModels;
 using AgGateway.ADAPT.ISOv4Plugin.ObjectModel;
-using AgGateway.ADAPT.ISOv4Plugin.ExtensionMethods;
-using AgGateway.ADAPT.ApplicationDataModel.Common;
-using System.Globalization;
+using AgGateway.ADAPT.ISOv4Plugin.Representation;
 
 namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
 {

--- a/ISOv4Plugin/Mappers/TaskMapper.cs
+++ b/ISOv4Plugin/Mappers/TaskMapper.cs
@@ -2,6 +2,8 @@
  * ISO standards can be purchased through the ANSI webstore at https://webstore.ansi.org
 */
 
+using System.Collections.Generic;
+using System.Linq;
 using AgGateway.ADAPT.ApplicationDataModel.Common;
 using AgGateway.ADAPT.ApplicationDataModel.Documents;
 using AgGateway.ADAPT.ApplicationDataModel.Equipment;
@@ -13,10 +15,8 @@ using AgGateway.ADAPT.ApplicationDataModel.Representations;
 using AgGateway.ADAPT.ISOv4Plugin.ExtensionMethods;
 using AgGateway.ADAPT.ISOv4Plugin.ISOEnumerations;
 using AgGateway.ADAPT.ISOv4Plugin.ISOModels;
+using AgGateway.ADAPT.ISOv4Plugin.Mappers.Factories;
 using AgGateway.ADAPT.ISOv4Plugin.Representation;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
 {
@@ -51,16 +51,16 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             }
         }
 
-        TimeLogMapper _timeLogMapper;
-        public TimeLogMapper TimeLogMapper
+        TimeLogMapperFactory _timeLogFactoryMapper;
+        public TimeLogMapperFactory TimeLogMapperFactory
         {
             get
             {
-                if (_timeLogMapper == null)
+                if (_timeLogFactoryMapper == null)
                 {
-                    _timeLogMapper = new TimeLogMapper(TaskDataMapper);
+                    _timeLogFactoryMapper = new TimeLogMapperFactory(TaskDataMapper);
                 }
-                return _timeLogMapper;
+                return _timeLogFactoryMapper;
             }
         }
 
@@ -192,7 +192,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             if (loggedData.OperationData.Any())
             {
                 //Time Logs
-                task.TimeLogs = TimeLogMapper.ExportTimeLogs(loggedData.OperationData, TaskDataPath).ToList();
+                task.TimeLogs = TimeLogMapperFactory.ExportTimeLogs(loggedData.OperationData, TaskDataPath).ToList();
 
                 //Connections
                 IEnumerable<int> taskEquipmentConfigIDs = loggedData.OperationData.SelectMany(o => o.EquipmentConfigurationIds);
@@ -639,7 +639,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                     rxID = _rxIDsByTask[isoLoggedTask.TaskID];
                 }
 
-                loggedData.OperationData = TimeLogMapper.ImportTimeLogs(isoLoggedTask, rxID);
+                loggedData.OperationData = TimeLogMapperFactory.ImportTimeLogs(isoLoggedTask, rxID);
             }
 
             //Connections

--- a/ISOv4Plugin/Mappers/TimeLogMapper.cs
+++ b/ISOv4Plugin/Mappers/TimeLogMapper.cs
@@ -2,25 +2,19 @@
  * ISO standards can be purchased through the ANSI webstore at https://webstore.ansi.org
 */
 
-using AgGateway.ADAPT.ISOv4Plugin.ExtensionMethods;
-using AgGateway.ADAPT.ISOv4Plugin.ISOModels;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using AgGateway.ADAPT.ApplicationDataModel.Logistics;
-using AgGateway.ADAPT.ApplicationDataModel.Shapes;
-using AgGateway.ADAPT.ISOv4Plugin.ISOEnumerations;
-using AgGateway.ADAPT.ApplicationDataModel.Guidance;
-using AgGateway.ADAPT.ApplicationDataModel.Products;
+using AgGateway.ADAPT.ApplicationDataModel.Common;
+using AgGateway.ADAPT.ApplicationDataModel.Equipment;
 using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
+using AgGateway.ADAPT.ApplicationDataModel.Shapes;
+using AgGateway.ADAPT.ISOv4Plugin.ExtensionMethods;
+using AgGateway.ADAPT.ISOv4Plugin.ISOEnumerations;
+using AgGateway.ADAPT.ISOv4Plugin.ISOModels;
 using AgGateway.ADAPT.ISOv4Plugin.ObjectModel;
 using AgGateway.ADAPT.ISOv4Plugin.Representation;
-using AgGateway.ADAPT.ApplicationDataModel.Equipment;
-using System.IO;
-using AgGateway.ADAPT.ApplicationDataModel.Common;
-using AgGateway.ADAPT.Representation.RepresentationSystem;
 using AgGateway.ADAPT.Representation.RepresentationSystem.ExtensionMethods;
 
 namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
@@ -28,12 +22,12 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
     public interface ITimeLogMapper
     {
         IEnumerable<ISOTimeLog> ExportTimeLogs(IEnumerable<OperationData> operationDatas, string dataPath);
-        IEnumerable<OperationData> ImportTimeLogs(ISOTask loggedTask, int? prescriptionID);
+        IEnumerable<OperationData> ImportTimeLogs(ISOTask loggedTask, IEnumerable<ISOTimeLog> timeLogs, int? prescriptionID);
     }
 
-    public class TimeLogMapper : BaseMapper, ITimeLogMapper
+    internal class TimeLogMapper : BaseMapper, ITimeLogMapper
     {
-        public TimeLogMapper(TaskDataMapper taskDataMapper) : base(taskDataMapper, "TLG")
+        internal TimeLogMapper(TaskDataMapper taskDataMapper) : base(taskDataMapper, "TLG")
         {
         }
 
@@ -281,10 +275,10 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
 
         #region Import
 
-        public IEnumerable<OperationData> ImportTimeLogs(ISOTask loggedTask, int? prescriptionID)
+        public virtual IEnumerable<OperationData> ImportTimeLogs(ISOTask loggedTask, IEnumerable<ISOTimeLog> timeLogs, int? prescriptionID)
         {
             List<OperationData> operations = new List<OperationData>();
-            foreach (ISOTimeLog isoTimeLog in loggedTask.TimeLogs)
+            foreach (ISOTimeLog isoTimeLog in timeLogs)
             {
                 IEnumerable<OperationData> operationData = ImportTimeLog(loggedTask, isoTimeLog, prescriptionID);
                 if (operationData != null)
@@ -296,7 +290,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             return operations;
         }
 
-        private IEnumerable<OperationData> ImportTimeLog(ISOTask loggedTask, ISOTimeLog isoTimeLog, int? prescriptionID)
+        protected IEnumerable<OperationData> ImportTimeLog(ISOTask loggedTask, ISOTimeLog isoTimeLog, int? prescriptionID)
         {
             WorkingDataMapper workingDataMapper = new WorkingDataMapper(new EnumeratedMeterFactory(), TaskDataMapper);
             SectionMapper sectionMapper = new SectionMapper(workingDataMapper, TaskDataMapper);
@@ -336,10 +330,11 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                     TaskDataMapper.AddError($"Timelog file {isoTimeLog.Filename} is invalid.  Skipping.", ex.Message, null, ex.StackTrace);
                     return null;
                 }
-                ISOTime time = isoTimeLog.GetTimeElement(this.TaskDataPath);
+                ISOTime time = GetTimeElementFromTimeLog(isoTimeLog);
 
                 //Identify unique devices represented in this TimeLog data
-                IEnumerable<string> deviceElementIDs = time.DataLogValues.Where(d => d.ProcessDataDDI != "DFFF" && d.ProcessDataDDI != "DFFE").Select(d => d.DeviceElementIdRef);
+                IEnumerable<string> deviceElementIDs = time.DataLogValues.Where(d => !d.ProcessDataDDI.EqualsIgnoreCase("DFFF") && !d.ProcessDataDDI.EqualsIgnoreCase("DFFE"))
+                    .Select(d => d.DeviceElementIdRef).Distinct().ToList();
                 Dictionary<ISODevice, HashSet<string>> loggedDeviceElementsByDevice = new Dictionary<ISODevice, HashSet<string>>();
                 foreach (string deviceElementID in deviceElementIDs)
                 {
@@ -398,6 +393,11 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             return null;
         }
 
+        protected virtual ISOTime GetTimeElementFromTimeLog(ISOTimeLog isoTimeLog)
+        {
+            return isoTimeLog.GetTimeElement(this.TaskDataPath);
+        }
+
         internal static List<int> GetDistinctProductIDs(TaskDataMapper taskDataMapper, Dictionary<string, List<ISOProductAllocation>> productAllocations)
         {
             HashSet<int> productIDs = new HashSet<int>();
@@ -420,9 +420,9 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             Dictionary<string, List<ISOProductAllocation>> output = new Dictionary<string, List<ISOProductAllocation>>();
             foreach (ISOProductAllocation pan in loggedTask.ProductAllocations.Where(p => !string.IsNullOrEmpty(p.DeviceElementIdRef)))
             {
-                if (dvc.DeviceElements.Select(d => d.DeviceElementId).Contains(pan.DeviceElementIdRef)) //Filter PANs by this DVC
+                ISODeviceElement deviceElement = dvc.DeviceElements.FirstOrDefault(d => d.DeviceElementId == pan.DeviceElementIdRef);
+                if (deviceElement != null) //Filter PANs by this DVC
                 {
-                    ISODeviceElement deviceElement = dvc.DeviceElements.First(d => d.DeviceElementId == pan.DeviceElementIdRef);
                     AddProductAllocationsForDeviceElement(output, pan, deviceElement);
                 }
             }
@@ -475,7 +475,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             return OperationTypeEnum.Unknown;
         }
 
-        private IEnumerable<ISOSpatialRow> ReadTimeLog(ISOTimeLog timeLog, string dataPath)
+        protected virtual IEnumerable<ISOSpatialRow> ReadTimeLog(ISOTimeLog timeLog, string dataPath)
         {
             ISOTime templateTime = timeLog.GetTimeElement(dataPath);
             string binName = string.Concat(timeLog.Filename, ".bin");
@@ -492,7 +492,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             return BinaryReader.ReadImplementGeometryValues(filePath, templateTime, dlvsToRead);
         }
 
-        private class BinaryReader
+        protected class BinaryReader
         {
             private static readonly DateTime _firstDayOf1980 = new DateTime(1980, 01, 01);
 

--- a/ISOv4Plugin/ObjectModel/ISOSpatialRow.cs
+++ b/ISOv4Plugin/ObjectModel/ISOSpatialRow.cs
@@ -21,5 +21,29 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ObjectModel
         public ushort? GpsUtcDate { get; set; }
         public DateTime? GpsUtcDateTime { get; set; }
         public List<SpatialValue> SpatialValues {get; set; }
+
+        /// <summary>
+        /// Merge SpatialValues from provided SpatialRow into this one.
+        /// </summary>
+        /// <param name="otherRow"></param>
+        /// <returns></returns>
+        public ISOSpatialRow Merge(ISOSpatialRow otherRow)
+        {
+            if (otherRow == null)
+            {
+                return this;
+            }
+
+            if (SpatialValues == null)
+            {
+                SpatialValues = new List<SpatialValue>();
+            }
+            if (otherRow.SpatialValues != null)
+            {
+                SpatialValues.AddRange(otherRow.SpatialValues);
+            }
+
+            return this;
+        }
     }
 }


### PR DESCRIPTION
This PR adds support for:
- using manufacturer private attributes (xml attributes that start with `P`) to fill in missing product properties.
- processing TLGs with more than 255 DLVs that are split across multiple .bin files. The data from these files is exposed as single OperationData entity.
- handling product allocations at different levels. The change prefers direct product allocation at the lowest level.
- correctly handling product component import.