### PR TITLE
Support multi-file timelogs

### DIFF
--- a/ISOv4Plugin/ExtensionMethods/ExtensionMethods.cs
+++ b/ISOv4Plugin/ExtensionMethods/ExtensionMethods.cs
@@ -2,21 +2,20 @@
  * ISO standards can be purchased through the ANSI webstore at https://webstore.ansi.org
 */
 
+using System;
 using System.Collections.Generic;
-using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using AgGateway.ADAPT.ApplicationDataModel.Common;
 using AgGateway.ADAPT.ApplicationDataModel.Equipment;
 using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
 using AgGateway.ADAPT.ApplicationDataModel.Representations;
-using AgGateway.ADAPT.ISOv4Plugin.ObjectModel;
+using AgGateway.ADAPT.ISOv4Plugin.ISOModels;
 using AgGateway.ADAPT.ISOv4Plugin.Mappers;
-using System;
-using System.IO;
+using AgGateway.ADAPT.ISOv4Plugin.ObjectModel;
 using AgGateway.ADAPT.ISOv4Plugin.Representation;
 using RepresentationUnitSystem = AgGateway.ADAPT.Representation.UnitSystem;
-using AgGateway.ADAPT.ISOv4Plugin.ISOModels;
 
 
 namespace AgGateway.ADAPT.ISOv4Plugin.ExtensionMethods
@@ -280,6 +279,62 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ExtensionMethods
                 return matchedFiles;
             }
             return new List<string>();
+        }
+
+        /// <summary>
+        /// Case-insensitive comparison of two strings
+        /// </summary>
+        /// <param name="value1"></param>
+        /// <param name="value2"></param>
+        /// <returns></returns>
+        public static bool EqualsIgnoreCase(this string value1, string value2)
+        {
+            return string.Equals(value1, value2, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Returns an earlier value of two DateTime objects
+        /// </summary>
+        /// <param name="time1"></param>
+        /// <param name="time2"></param>
+        /// <returns></returns>
+        public static DateTime? Min(this DateTime? time1, DateTime? time2)
+        {
+            if (time1.HasValue && time2.HasValue)
+            {
+                return time1.Value <= time2.Value ? time1: time2;
+            }
+            return time1.HasValue ? time1 : time2;
+        }
+
+        /// <summary>
+        /// Returns a later value of two DateTime objects
+        /// </summary>
+        /// <param name="time1"></param>
+        /// <param name="time2"></param>
+        /// <returns></returns>
+        public static DateTime? Max(this DateTime? time1, DateTime? time2)
+        {
+            if (time1.HasValue && time2.HasValue)
+            {
+                return time1.Value >= time2.Value ? time1 : time2;
+            }
+            return time1.HasValue ? time1 : time2;
+        }
+
+        /// <summary>
+        /// Sums two integer values
+        /// </summary>
+        /// <param name="value1"></param>
+        /// <param name="value2"></param>
+        /// <returns></returns>
+        public static uint? Sum(this uint? value1, uint? value2)
+        {
+            if (value1.HasValue && value1.HasValue)
+            {
+                return value1 + value2;
+            }
+            return value1.HasValue ? value1 : value2;
         }
     }
 }

--- a/ISOv4Plugin/ExtensionMethods/ExtensionMethods.cs
+++ b/ISOv4Plugin/ExtensionMethods/ExtensionMethods.cs
@@ -323,16 +323,16 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ExtensionMethods
         }
 
         /// <summary>
-        /// Sums two integer values
+        /// Max of two integer values
         /// </summary>
         /// <param name="value1"></param>
         /// <param name="value2"></param>
         /// <returns></returns>
-        public static uint? Sum(this uint? value1, uint? value2)
+        public static uint? Max(this uint? value1, uint? value2)
         {
             if (value1.HasValue && value1.HasValue)
             {
-                return value1 + value2;
+                return value1 >= value2 ? value1 : value2;
             }
             return value1.HasValue ? value1 : value2;
         }

--- a/ISOv4Plugin/ISOModels/ISOTime.cs
+++ b/ISOv4Plugin/ISOModels/ISOTime.cs
@@ -2,13 +2,12 @@
  * ISO standards can be purchased through the ANSI webstore at https://webstore.ansi.org
 */
 
-using AgGateway.ADAPT.ApplicationDataModel.ADM;
-using AgGateway.ADAPT.ISOv4Plugin.ExtensionMethods;
-using AgGateway.ADAPT.ISOv4Plugin.ISOEnumerations;
-using AgGateway.ADAPT.ISOv4Plugin.ObjectModel;
 using System;
 using System.Collections.Generic;
 using System.Xml;
+using AgGateway.ADAPT.ApplicationDataModel.ADM;
+using AgGateway.ADAPT.ISOv4Plugin.ExtensionMethods;
+using AgGateway.ADAPT.ISOv4Plugin.ISOEnumerations;
 
 namespace AgGateway.ADAPT.ISOv4Plugin.ISOModels
 {
@@ -104,6 +103,35 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ISOModels
             Positions.ForEach(i => i.Validate(errors));
             DataLogValues.ForEach(i => i.Validate(errors));
             return errors;
+        }
+
+        public static ISOTime Merge(ISOTime time, ISOTime otherTime)
+        {
+            if (time == null)
+            {
+                return otherTime;
+            }
+            if (otherTime == null)
+            {
+                return time;
+            }
+
+            ISOTime result = new ISOTime
+            {
+                Start = time.Start.Min(otherTime.Start),
+                Stop = time.Stop.Max(otherTime.Stop),
+                Duration = time.Duration.Sum(otherTime.Duration),
+                Type = time.Type == 0 ? otherTime.Type : time.Type,
+                HasStart = time.HasStart || otherTime.HasStart,
+                HasStop = time.HasStop || otherTime.HasStop,
+                HasDuration = time.HasDuration || otherTime.HasDuration,
+                HasType = time.HasType || otherTime.HasType
+            };
+
+            result.DataLogValues.AddRange(time.DataLogValues);
+            result.DataLogValues.AddRange(otherTime.DataLogValues);
+
+            return result;
         }
     }
 }

--- a/ISOv4Plugin/ISOModels/ISOTime.cs
+++ b/ISOv4Plugin/ISOModels/ISOTime.cs
@@ -118,9 +118,12 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ISOModels
 
             ISOTime result = new ISOTime
             {
+                // Pick earlier date
                 Start = time.Start.Min(otherTime.Start),
+                // Pick later date
                 Stop = time.Stop.Max(otherTime.Stop),
-                Duration = time.Duration.Sum(otherTime.Duration),
+                // Pick max from both since they most likely overlap
+                Duration = time.Duration.Max(otherTime.Duration),
                 Type = time.Type == 0 ? otherTime.Type : time.Type,
                 HasStart = time.HasStart || otherTime.HasStart,
                 HasStop = time.HasStop || otherTime.HasStop,

--- a/ISOv4Plugin/Mappers/Factories/TimeLogMapperFactory.cs
+++ b/ISOv4Plugin/Mappers/Factories/TimeLogMapperFactory.cs
@@ -2,6 +2,7 @@
  * ISO standards can be purchased through the ANSI webstore at https://webstore.ansi.org
 */
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
@@ -10,7 +11,7 @@ using AgGateway.ADAPT.ISOv4Plugin.ISOModels;
 namespace AgGateway.ADAPT.ISOv4Plugin.Mappers.Factories
 {
     /// <summary>
-    /// Factory class to helping process ISOTimeLog data
+    /// Factory class to help process ISOTimeLog data
     /// </summary>
     public class TimeLogMapperFactory
     {
@@ -18,11 +19,29 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers.Factories
         private readonly MultiFileTimeLogMapper _multiFileTimeLogMapper;
         private readonly TaskDataMapper _taskDataMapper;
 
-        // Helper class to analyze ISOTimeLog data
-        private class TimeLogHelper
+        // A wrapper class to hold together ISOTimeLog and included ISODataLogValues.
+        // This avoids multiple calls to ISOTimeLog.GetTimeElement() which performs xml parsing on each call.
+        private class TimeLogWrapper
         {
             public ISOTimeLog ISOTimeLog { get; set; }
-            public ISOTime ISOTime { get; set; }
+            public List<ISODataLogValue> DataLogValues { get; set; }
+        }
+
+        // Class representing a group of TimeLogWrapper objects that should be processed together
+        private class TimeLogWrapperGroup : List<TimeLogWrapper>
+        {
+            public TimeLogWrapperGroup()
+            {
+                KeepAsGroup = false;
+            }
+
+            public bool KeepAsGroup { get; set; }
+        }
+
+        // Class representing a group of ISOTimeLog objects that will be processed as single entity
+        private class TimeLogGroup : List<ISOTimeLog>
+        {
+            public TimeLogGroup(IEnumerable<ISOTimeLog> collection): base(collection) { }
         }
 
         public TimeLogMapperFactory(TaskDataMapper taskDataMapper)
@@ -34,18 +53,12 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers.Factories
 
         public IEnumerable<OperationData> ImportTimeLogs(ISOTask loggedTask, int? prescriptionID)
         {
-            bool enableMultiFileTimeLogs = false;
-            if (_taskDataMapper.Properties != null)
-            {
-                bool.TryParse(_taskDataMapper.Properties.GetProperty(TaskDataMapper.EnableMultiFileTimeLogs), out enableMultiFileTimeLogs);
-            }
-
             var timeLogGroups = GetTimeLogGroups(loggedTask);
 
             var opearationDats = new List<OperationData>();
             foreach (var timeLogGroup in timeLogGroups)
             {
-                opearationDats.AddRange(enableMultiFileTimeLogs && timeLogGroup.Count > 1
+                opearationDats.AddRange(timeLogGroup.Count > 1
                     ? _multiFileTimeLogMapper.ImportTimeLogs(loggedTask, timeLogGroup, prescriptionID)
                     : _timeLogMapper.ImportTimeLogs(loggedTask, timeLogGroup, prescriptionID));
             }
@@ -58,33 +71,33 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers.Factories
         }
 
 
-        private List<List<ISOTimeLog>> GetTimeLogGroups(ISOTask loggedTask)
+        private List<TimeLogGroup> GetTimeLogGroups(ISOTask loggedTask)
         {
             var dataPath = _timeLogMapper.TaskDataPath;
 
             var timeLogGroups = GroupByDataLogValueCount(loggedTask, dataPath);
+            timeLogGroups = HandleRollOverScenario(timeLogGroups);
             timeLogGroups = HandleDuplicateDataLogValues(timeLogGroups);
 
-            return timeLogGroups.Select(x => x.Select(y => y.ISOTimeLog).ToList()).ToList();
+            return timeLogGroups.Select(x => new TimeLogGroup(x.Select(y => y.ISOTimeLog).ToList())).ToList();
         }
 
-        private List<List<TimeLogHelper>> HandleDuplicateDataLogValues(List<List<TimeLogHelper>> timeLogGroups)
+        private List<TimeLogWrapperGroup> HandleDuplicateDataLogValues(List<TimeLogWrapperGroup> timeLogGroups)
         {
-            var result = new List<List<TimeLogHelper>>();
+            var result = new List<TimeLogWrapperGroup> ();
             // Check if all DataLogValues are referencing unique combination of DET/DDI.
             // Exclude PGN-based DLVs as they are not unique.
             foreach (var timeLogGroup in timeLogGroups)
             {
-                var hasDuplicatesByElementAndDDI = timeLogGroup.SelectMany(x => x.ISOTime.DataLogValues)
+                var duplicatesByElementAndDDI = timeLogGroup.SelectMany(x => x.DataLogValues)
                     .Where(x => x.DataLogPGN == null)
                     .GroupBy(x => new { x.DeviceElementIdRef, x.ProcessDataDDI })
-                    .Where(x => x.Count() > 1)
-                    .Any();
-                if (hasDuplicatesByElementAndDDI)
+                    .Where(x => x.Count() > 1);
+                if (!timeLogGroup.KeepAsGroup && duplicatesByElementAndDDI.Any())
                 {
                     // Some DataLogValues are referencing same combination of DET/DDI.
                     // Split them into separate groups
-                    result.AddRange(timeLogGroup.Select(x => new List<TimeLogHelper> { x }));
+                    result.AddRange(timeLogGroup.Select(x => new TimeLogWrapperGroup { x }));
                 }
                 else
                 {
@@ -94,24 +107,61 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers.Factories
             return result;
         }
 
-        private List<List<TimeLogHelper>> GroupByDataLogValueCount(ISOTask loggedTask, string dataPath)
+        private List<TimeLogWrapperGroup> HandleRollOverScenario(List<TimeLogWrapperGroup> timeLogGroups)
+        {
+            // Initial TLG files with less than 255 DLVs could be changed
+            // by appending more DLVs to then in the process. The other file where these DLVS
+            // are coming from is no longer written in.
+            foreach (var timeLogGroup in timeLogGroups)
+            {
+                // Unique device element ids from all duplicate DLVs
+                var duplicateDeviceElementIds = timeLogGroup.SelectMany(y => y.DataLogValues)
+                    .Where(x => x.DataLogPGN == null)
+                    .GroupBy(x => new { x.DeviceElementIdRef, x.ProcessDataDDI })
+                    .Where(x => x.Count() > 1)
+                    .Select(x => x.Key.DeviceElementIdRef)
+                    .Distinct()
+                    .ToList();
+                if (duplicateDeviceElementIds.Count <= 0)
+                {
+                    continue;
+                }
+
+                // Count how many TLGs have 255 DLVs
+                var timeLogs = timeLogGroup.Where(x => x.DataLogValues.Any(y => duplicateDeviceElementIds.Contains(y.DeviceElementIdRef)))
+                    .Where(x => x.DataLogValues.Count == 255)
+                    .ToList();
+
+                // Multiple TLGs with 255 DLVs in them. Most likely a roll-over scenario
+                if (timeLogs.Count > 1)
+                {
+                    // Keep them as a single group
+                    timeLogGroup.KeepAsGroup = true;
+                }
+            }
+
+            return timeLogGroups;
+        }
+
+        private List<TimeLogWrapperGroup> GroupByDataLogValueCount(ISOTask loggedTask, string dataPath)
         {
             // All consequent time logs with 255 DLVs are kept together as a group.
-            var timeLogGroups = new List<List<TimeLogHelper>>();
-            var logGroup = new List<TimeLogHelper>();
+            var timeLogGroups = new List<TimeLogWrapperGroup>();
+            var logGroup = new TimeLogWrapperGroup();
             foreach (var timeLog in loggedTask.TimeLogs)
             {
                 ISOTime templateTime = timeLog.GetTimeElement(dataPath);
-                logGroup.Add(new TimeLogHelper { ISOTime = templateTime, ISOTimeLog = timeLog });
+                logGroup.Add(new TimeLogWrapper { DataLogValues = templateTime.DataLogValues, ISOTimeLog = timeLog });
                 // A time log with less than 255 DLVs found. Add it to current group
                 // and start a new one.
                 if (templateTime.DataLogValues.Count < 255)
                 {
                     timeLogGroups.Add(logGroup);
-                    logGroup = new List<TimeLogHelper>();
+                    logGroup = new TimeLogWrapperGroup();
                 }
             }
-            if (logGroup.Count > 1)
+            // Add remaning log group
+            if (logGroup.Count > 0)
             {
                 timeLogGroups.Add(logGroup);
             }

--- a/ISOv4Plugin/Mappers/Factories/TimeLogMapperFactory.cs
+++ b/ISOv4Plugin/Mappers/Factories/TimeLogMapperFactory.cs
@@ -1,0 +1,121 @@
+/*
+ * ISO standards can be purchased through the ANSI webstore at https://webstore.ansi.org
+*/
+
+using System.Collections.Generic;
+using System.Linq;
+using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
+using AgGateway.ADAPT.ISOv4Plugin.ISOModels;
+
+namespace AgGateway.ADAPT.ISOv4Plugin.Mappers.Factories
+{
+    /// <summary>
+    /// Factory class to helping process ISOTimeLog data
+    /// </summary>
+    public class TimeLogMapperFactory
+    {
+        private readonly TimeLogMapper _timeLogMapper;
+        private readonly MultiFileTimeLogMapper _multiFileTimeLogMapper;
+        private readonly TaskDataMapper _taskDataMapper;
+
+        // Helper class to analyze ISOTimeLog data
+        private class TimeLogHelper
+        {
+            public ISOTimeLog ISOTimeLog { get; set; }
+            public ISOTime ISOTime { get; set; }
+        }
+
+        public TimeLogMapperFactory(TaskDataMapper taskDataMapper)
+        {
+            _taskDataMapper = taskDataMapper;
+            _timeLogMapper = new TimeLogMapper(taskDataMapper);
+            _multiFileTimeLogMapper = new MultiFileTimeLogMapper(taskDataMapper);
+        }
+
+        public IEnumerable<OperationData> ImportTimeLogs(ISOTask loggedTask, int? prescriptionID)
+        {
+            bool enableMultiFileTimeLogs = false;
+            if (_taskDataMapper.Properties != null)
+            {
+                bool.TryParse(_taskDataMapper.Properties.GetProperty(TaskDataMapper.EnableMultiFileTimeLogs), out enableMultiFileTimeLogs);
+            }
+
+            var timeLogGroups = GetTimeLogGroups(loggedTask);
+
+            var opearationDats = new List<OperationData>();
+            foreach (var timeLogGroup in timeLogGroups)
+            {
+                opearationDats.AddRange(enableMultiFileTimeLogs && timeLogGroup.Count > 1
+                    ? _multiFileTimeLogMapper.ImportTimeLogs(loggedTask, timeLogGroup, prescriptionID)
+                    : _timeLogMapper.ImportTimeLogs(loggedTask, timeLogGroup, prescriptionID));
+            }
+            return opearationDats;
+        }
+
+        public IEnumerable<ISOTimeLog> ExportTimeLogs(IEnumerable<OperationData> operationDatas, string dataPath)
+        {
+            return _timeLogMapper.ExportTimeLogs(operationDatas, dataPath);
+        }
+
+
+        private List<List<ISOTimeLog>> GetTimeLogGroups(ISOTask loggedTask)
+        {
+            var dataPath = _timeLogMapper.TaskDataPath;
+
+            var timeLogGroups = GroupByDataLogValueCount(loggedTask, dataPath);
+            timeLogGroups = HandleDuplicateDataLogValues(timeLogGroups);
+
+            return timeLogGroups.Select(x => x.Select(y => y.ISOTimeLog).ToList()).ToList();
+        }
+
+        private List<List<TimeLogHelper>> HandleDuplicateDataLogValues(List<List<TimeLogHelper>> timeLogGroups)
+        {
+            var result = new List<List<TimeLogHelper>>();
+            // Check if all DataLogValues are referencing unique combination of DET/DDI.
+            // Exclude PGN-based DLVs as they are not unique.
+            foreach (var timeLogGroup in timeLogGroups)
+            {
+                var hasDuplicatesByElementAndDDI = timeLogGroup.SelectMany(x => x.ISOTime.DataLogValues)
+                    .Where(x => x.DataLogPGN == null)
+                    .GroupBy(x => new { x.DeviceElementIdRef, x.ProcessDataDDI })
+                    .Where(x => x.Count() > 1)
+                    .Any();
+                if (hasDuplicatesByElementAndDDI)
+                {
+                    // Some DataLogValues are referencing same combination of DET/DDI.
+                    // Split them into separate groups
+                    result.AddRange(timeLogGroup.Select(x => new List<TimeLogHelper> { x }));
+                }
+                else
+                {
+                    result.Add(timeLogGroup);
+                }
+            }
+            return result;
+        }
+
+        private List<List<TimeLogHelper>> GroupByDataLogValueCount(ISOTask loggedTask, string dataPath)
+        {
+            // All consequent time logs with 255 DLVs are kept together as a group.
+            var timeLogGroups = new List<List<TimeLogHelper>>();
+            var logGroup = new List<TimeLogHelper>();
+            foreach (var timeLog in loggedTask.TimeLogs)
+            {
+                ISOTime templateTime = timeLog.GetTimeElement(dataPath);
+                logGroup.Add(new TimeLogHelper { ISOTime = templateTime, ISOTimeLog = timeLog });
+                // A time log with less than 255 DLVs found. Add it to current group
+                // and start a new one.
+                if (templateTime.DataLogValues.Count < 255)
+                {
+                    timeLogGroups.Add(logGroup);
+                    logGroup = new List<TimeLogHelper>();
+                }
+            }
+            if (logGroup.Count > 1)
+            {
+                timeLogGroups.Add(logGroup);
+            }
+            return timeLogGroups;
+        }
+    }
+}

--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/SpatialRecordMapper.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/SpatialRecordMapper.cs
@@ -89,9 +89,10 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
 
         private void SetEnumeratedMeterValue(ISOSpatialRow isoSpatialRow, EnumeratedWorkingData meter, SpatialRecord spatialRecord)
         {
+            var isoDataLogValue = _workingDataMapper.DataLogValuesByWorkingDataID[meter.Id.ReferenceId];
             var isoValue = isoSpatialRow.SpatialValues.FirstOrDefault(v =>
-                    v.DataLogValue.DeviceElementIdRef == _workingDataMapper.DataLogValuesByWorkingDataID[meter.Id.ReferenceId].DeviceElementIdRef &&
-                    v.DataLogValue.ProcessDataDDI == _workingDataMapper.DataLogValuesByWorkingDataID[meter.Id.ReferenceId].ProcessDataDDI);
+                    v.DataLogValue.DeviceElementIdRef == isoDataLogValue.DeviceElementIdRef &&
+                    v.DataLogValue.ProcessDataDDI == isoDataLogValue.ProcessDataDDI);
             if (isoValue != null)
             {
                 var isoEnumeratedMeter = meter as ISOEnumeratedMeter;
@@ -108,11 +109,15 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
 
         private void SetNumericMeterValue(ISOSpatialRow isoSpatialRow, NumericWorkingData meter, SpatialRecord spatialRecord, Dictionary<string, List<ISOProductAllocation>> productAllocations)
         {
-            var isoValue = isoSpatialRow.SpatialValues.FirstOrDefault(v =>
+            var dataLogValue = _workingDataMapper.DataLogValuesByWorkingDataID.ContainsKey(meter.Id.ReferenceId)
+                ? _workingDataMapper.DataLogValuesByWorkingDataID[meter.Id.ReferenceId]
+                : null;
+            var isoValue = dataLogValue != null
+                           ? isoSpatialRow.SpatialValues.FirstOrDefault(v =>
                                 v.DataLogValue.ProcessDataDDI != "DFFE" &&
-                                _workingDataMapper.DataLogValuesByWorkingDataID.ContainsKey(meter.Id.ReferenceId) &&
-                                v.DataLogValue.DeviceElementIdRef == _workingDataMapper.DataLogValuesByWorkingDataID[meter.Id.ReferenceId].DeviceElementIdRef &&
-                                v.DataLogValue.ProcessDataDDI == _workingDataMapper.DataLogValuesByWorkingDataID[meter.Id.ReferenceId].ProcessDataDDI);
+                                v.DataLogValue.DeviceElementIdRef == dataLogValue.DeviceElementIdRef &&
+                                v.DataLogValue.ProcessDataDDI == dataLogValue.ProcessDataDDI)
+                           : null;
 
 
             if (isoValue != null)

--- a/ISOv4Plugin/Mappers/MultiFileTimeLogMapper.cs
+++ b/ISOv4Plugin/Mappers/MultiFileTimeLogMapper.cs
@@ -1,0 +1,133 @@
+/*
+ * ISO standards can be purchased through the ANSI webstore at https://webstore.ansi.org
+*/
+
+using System.Collections.Generic;
+using System.Linq;
+using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
+using AgGateway.ADAPT.ISOv4Plugin.ISOModels;
+using AgGateway.ADAPT.ISOv4Plugin.ObjectModel;
+
+namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
+{
+    /// <summary>
+    /// A TimeLogMapper class with support for data split between two or more ISO TLG files.
+    /// </summary>
+    internal class MultiFileTimeLogMapper : TimeLogMapper, ITimeLogMapper
+    {
+        private ISOTime _combinedTime;
+        private IEnumerable<ISOTimeLog> _timeLogs;
+
+        // Helper class to keep track of individual TLG files and current record from each
+        private class BinaryReaderHelper
+        {
+            public IEnumerator<ISOSpatialRow> Enumerator { get; set; }
+            public ISOSpatialRow CurrentRecord { get; set; }
+        }
+
+        internal MultiFileTimeLogMapper(TaskDataMapper taskDataMapper)
+            : base(taskDataMapper)
+        {
+        }
+
+        #region Import
+
+        public override IEnumerable<OperationData> ImportTimeLogs(ISOTask loggedTask, IEnumerable<ISOTimeLog> timeLogs, int? prescriptionID)
+        {
+            _timeLogs = timeLogs;
+            // Combine ISOTime elements from each TimeLog into one.
+            _combinedTime = CreateCombinedTime();
+            // Read data from all timelogs as if it was a single file.
+            // Pass first available TimeLog to avoid breaking base class.
+            return ImportTimeLog(loggedTask, timeLogs.First(), prescriptionID);
+        }
+
+        protected override IEnumerable<ISOSpatialRow> ReadTimeLog(ISOTimeLog _timeLog, string _dataPath)
+        {
+            List<BinaryReaderHelper> readers = new List<BinaryReaderHelper>();
+            try
+            {
+                // Obtain binary readers for each time log
+                foreach (var timeLog in _timeLogs)
+                {
+                    var reader = base.ReadTimeLog(timeLog, TaskDataPath);
+                    if (reader != null)
+                    {
+                        readers.Add(new BinaryReaderHelper
+                        {
+                            Enumerator = reader.GetEnumerator()
+                        });
+                    }
+                }
+
+                return ReadFromBinaryReaders(readers);
+            }
+            finally
+            {
+                // Clean up readers
+                foreach (var reader in readers)
+                {
+                    reader.Enumerator?.Dispose();
+                }
+            }
+        }
+
+        private IEnumerable<ISOSpatialRow> ReadFromBinaryReaders(List<BinaryReaderHelper> readers)
+        {
+            while (true)
+            {
+                // Read next record from each time log
+                foreach (var reader in readers)
+                {
+                    if (reader.CurrentRecord == null)
+                    {
+                        reader.CurrentRecord = reader.Enumerator.MoveNext() ? reader.Enumerator.Current : null;
+                    }
+                }
+
+                // Only get readers which still have records;
+                var readersWithData = readers.Where(x => x.CurrentRecord != null).ToList();
+                if (readersWithData.Count == 0)
+                {
+                    // No more records in each file. Stop processing.
+                    break;
+                }
+
+                // Group records by TimeStart and East/North position, and then grab ones with earliest TimeStart.
+                var candidates = readersWithData.GroupBy(x => new { x.CurrentRecord.TimeStart, x.CurrentRecord.EastPosition, x.CurrentRecord.NorthPosition })
+                    .OrderBy(x => x.Key.TimeStart)
+                    .First().ToList();
+
+                // Merge data from all candidates into first record
+                ISOSpatialRow result = null;
+                foreach (var candidate in candidates)
+                {
+                    result = result == null ? candidate.CurrentRecord : result.Merge(candidate.CurrentRecord);
+                    // Clear current record to force reading next one
+                    candidate.CurrentRecord = null;
+                }
+
+                yield return result;
+            }
+        }
+
+        protected override ISOTime GetTimeElmenetFromTimeLog(ISOTimeLog isoTimeLog)
+        {
+            // Always return a combined ISOTime record.
+            return _combinedTime;
+        }
+
+        private ISOTime CreateCombinedTime()
+        {
+            ISOTime result = null;
+            foreach (var timeLog in _timeLogs)
+            {
+                var time = timeLog.GetTimeElement(TaskDataPath);
+                result = ISOTime.Merge(result, time);
+            }
+            return result;
+        }
+
+        #endregion Import
+    }
+}

--- a/ISOv4Plugin/Mappers/TaskDataMapper.cs
+++ b/ISOv4Plugin/Mappers/TaskDataMapper.cs
@@ -32,7 +32,6 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
         public const string SpatialRecordDeferredExecution = "SpatialRecordDeferredExecution";
         public const string MergeSingleBinsIntoBoom = "MergeSingleBinsIntoBoom";
         public const string ExportVersion = "ExportVersion"; //Version "3" or "4"
-        public const string EnableMultiFileTimeLogs = "EnableMultiFileTimeLogs";
 
         public TaskDataMapper(string dataPath, Properties properties)
         {

--- a/ISOv4Plugin/Mappers/TaskDataMapper.cs
+++ b/ISOv4Plugin/Mappers/TaskDataMapper.cs
@@ -4,21 +4,17 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using AgGateway.ADAPT.ISOv4Plugin.ISOModels;
 using AgGateway.ADAPT.ApplicationDataModel.ADM;
+using AgGateway.ADAPT.ApplicationDataModel.Common;
+using AgGateway.ADAPT.ApplicationDataModel.Documents;
 using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
 using AgGateway.ADAPT.ApplicationDataModel.Logistics;
 using AgGateway.ADAPT.ApplicationDataModel.Products;
-using AgGateway.ADAPT.ApplicationDataModel.Documents;
-using AgGateway.ADAPT.ISOv4Plugin.Representation;
-using AgGateway.ADAPT.ApplicationDataModel.Equipment;
+using AgGateway.ADAPT.ISOv4Plugin.ISOModels;
 using AgGateway.ADAPT.ISOv4Plugin.ObjectModel;
-using AgGateway.ADAPT.ISOv4Plugin.ExtensionMethods;
-using AgGateway.ADAPT.ApplicationDataModel.Common;
-using System.Globalization;
+using AgGateway.ADAPT.ISOv4Plugin.Representation;
 
 namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
 {
@@ -36,6 +32,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
         public const string SpatialRecordDeferredExecution = "SpatialRecordDeferredExecution";
         public const string MergeSingleBinsIntoBoom = "MergeSingleBinsIntoBoom";
         public const string ExportVersion = "ExportVersion"; //Version "3" or "4"
+        public const string EnableMultiFileTimeLogs = "EnableMultiFileTimeLogs";
 
         public TaskDataMapper(string dataPath, Properties properties)
         {

--- a/ISOv4Plugin/Mappers/TaskMapper.cs
+++ b/ISOv4Plugin/Mappers/TaskMapper.cs
@@ -2,6 +2,8 @@
  * ISO standards can be purchased through the ANSI webstore at https://webstore.ansi.org
 */
 
+using System.Collections.Generic;
+using System.Linq;
 using AgGateway.ADAPT.ApplicationDataModel.Common;
 using AgGateway.ADAPT.ApplicationDataModel.Documents;
 using AgGateway.ADAPT.ApplicationDataModel.Equipment;
@@ -13,10 +15,8 @@ using AgGateway.ADAPT.ApplicationDataModel.Representations;
 using AgGateway.ADAPT.ISOv4Plugin.ExtensionMethods;
 using AgGateway.ADAPT.ISOv4Plugin.ISOEnumerations;
 using AgGateway.ADAPT.ISOv4Plugin.ISOModels;
+using AgGateway.ADAPT.ISOv4Plugin.Mappers.Factories;
 using AgGateway.ADAPT.ISOv4Plugin.Representation;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
 {
@@ -51,16 +51,16 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             }
         }
 
-        TimeLogMapper _timeLogMapper;
-        public TimeLogMapper TimeLogMapper
+        TimeLogMapperFactory _timeLogFactoryMapper;
+        public TimeLogMapperFactory TimeLogMapperFactory
         {
             get
             {
-                if (_timeLogMapper == null)
+                if (_timeLogFactoryMapper == null)
                 {
-                    _timeLogMapper = new TimeLogMapper(TaskDataMapper);
+                    _timeLogFactoryMapper = new TimeLogMapperFactory(TaskDataMapper);
                 }
-                return _timeLogMapper;
+                return _timeLogFactoryMapper;
             }
         }
 
@@ -192,7 +192,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             if (loggedData.OperationData.Any())
             {
                 //Time Logs
-                task.TimeLogs = TimeLogMapper.ExportTimeLogs(loggedData.OperationData, TaskDataPath).ToList();
+                task.TimeLogs = TimeLogMapperFactory.ExportTimeLogs(loggedData.OperationData, TaskDataPath).ToList();
 
                 //Connections
                 IEnumerable<int> taskEquipmentConfigIDs = loggedData.OperationData.SelectMany(o => o.EquipmentConfigurationIds);
@@ -639,7 +639,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                     rxID = _rxIDsByTask[isoLoggedTask.TaskID];
                 }
 
-                loggedData.OperationData = TimeLogMapper.ImportTimeLogs(isoLoggedTask, rxID);
+                loggedData.OperationData = TimeLogMapperFactory.ImportTimeLogs(isoLoggedTask, rxID);
             }
 
             //Connections

--- a/ISOv4Plugin/Mappers/TimeLogMapper.cs
+++ b/ISOv4Plugin/Mappers/TimeLogMapper.cs
@@ -330,7 +330,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                     TaskDataMapper.AddError($"Timelog file {isoTimeLog.Filename} is invalid.  Skipping.", ex.Message, null, ex.StackTrace);
                     return null;
                 }
-                ISOTime time = GetTimeElmenetFromTimeLog(isoTimeLog);
+                ISOTime time = GetTimeElementFromTimeLog(isoTimeLog);
 
                 //Identify unique devices represented in this TimeLog data
                 IEnumerable<string> deviceElementIDs = time.DataLogValues.Where(d => !d.ProcessDataDDI.EqualsIgnoreCase("DFFF") && !d.ProcessDataDDI.EqualsIgnoreCase("DFFE"))
@@ -393,7 +393,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             return null;
         }
 
-        protected virtual ISOTime GetTimeElmenetFromTimeLog(ISOTimeLog isoTimeLog)
+        protected virtual ISOTime GetTimeElementFromTimeLog(ISOTimeLog isoTimeLog)
         {
             return isoTimeLog.GetTimeElement(this.TaskDataPath);
         }

--- a/ISOv4Plugin/ObjectModel/ISOSpatialRow.cs
+++ b/ISOv4Plugin/ObjectModel/ISOSpatialRow.cs
@@ -21,5 +21,29 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ObjectModel
         public ushort? GpsUtcDate { get; set; }
         public DateTime? GpsUtcDateTime { get; set; }
         public List<SpatialValue> SpatialValues {get; set; }
+
+        /// <summary>
+        /// Merge SpatialValues from provided SpatialRow into this one.
+        /// </summary>
+        /// <param name="otherRow"></param>
+        /// <returns></returns>
+        public ISOSpatialRow Merge(ISOSpatialRow otherRow)
+        {
+            if (otherRow == null)
+            {
+                return this;
+            }
+
+            if (SpatialValues == null)
+            {
+                SpatialValues = new List<SpatialValue>();
+            }
+            if (otherRow.SpatialValues != null)
+            {
+                SpatialValues.AddRange(otherRow.SpatialValues);
+            }
+
+            return this;
+        }
     }
 }


### PR DESCRIPTION
This PR adds support for processing TLGs with more than 255 DLVs that are split across multiple .bin files. The data from these files is exposed as single `OperationData` entity.