### PR TITLE
Split time logs with different types of products into separate operations

### DIFF
--- a/ISOv4Plugin/Mappers/ProductMapper.cs
+++ b/ISOv4Plugin/Mappers/ProductMapper.cs
@@ -226,7 +226,9 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             product.Form = _manufacturer?.GetProductForm(isoProduct) ?? product.Form;
 
             // Category
-            product.Category = _manufacturer?.GetProductCategory(isoProduct) ?? CategoryEnum.Unknown;
+            product.Category = _manufacturer?.GetProductCategory(isoProduct) ?? (product.ProductType == ProductTypeEnum.Variety
+                                                                                    ? CategoryEnum.Variety
+                                                                                    : CategoryEnum.Unknown);
 
             // Update ProductType
             if (product.ProductType == ProductTypeEnum.Generic && product.Category != CategoryEnum.Unknown)


### PR DESCRIPTION
This PR includes following changes:
- set product category to Variety if product type is Variety
- splits operations with multiple forms of products (liquid, granular, etc.) into separate operations