### PR TITLE
Fix DateTime comparison when determining which ISOProductAllocation governs the SpatialRecord timestamp

### DIFF
--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/SpatialRecordMapper.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/SpatialRecordMapper.cs
@@ -211,16 +211,22 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             if (dateTime.Kind == DateTimeKind.Utc)
                 return dateTime;
 
+            DateTime utc;
             if (dateTime.Kind == DateTimeKind.Local)
-                return dateTime.ToUniversalTime();
-
-            if (dateTime.Kind == DateTimeKind.Unspecified && _taskDataMapper.GPSToLocalDelta.HasValue)
             {
-                return new DateTime(dateTime.AddHours(- _taskDataMapper.GPSToLocalDelta.Value).Ticks, DateTimeKind.Utc);
+                utc = dateTime.ToUniversalTime();
+            }
+            else if (dateTime.Kind == DateTimeKind.Unspecified && _taskDataMapper.GPSToLocalDelta.HasValue)
+            {
+                utc = new DateTime(dateTime.AddHours(- _taskDataMapper.GPSToLocalDelta.Value).Ticks, DateTimeKind.Utc);
+            }
+            else
+            {
+                // Nothing left to try; return original value
+                utc = dateTime;
             }
 
-            // Nothing left to try; return original value
-            return dateTime;
+            return utc;
         }
 
         private DateTime? Offset(DateTime? input)


### PR DESCRIPTION
We had some data in which a different seed product was used driving up to the field than was actually applied on the field. However, once the data was imported, the first (incorrect) seed product was applied to the entire field. The cause was tracked down to the DateTime comparison when determining the ISOProductAllocation, which is done by comparing time windows. The comparison failed because we were comparing spatialRecord timestamps (whose Kind property was Unspecified) against ISOProductAllocation Start and Stop values (whose Kind property was Local).

The fix converts DateTimes to UTC before doing the comparison. For the Unspecified DateTimes, we apply the `TaskDataMapper.GPSToLocalDelta` value.