### PR TITLE
Parent product allocations

### DIFF
--- a/ISOv4Plugin/ISOv4Plugin.csproj
+++ b/ISOv4Plugin/ISOv4Plugin.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AgGatewayADAPTFramework" Version="3.0.0" />
+    <PackageReference Include="AgGatewayADAPTFramework" Version="3.0.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Allow for identifying product allocations via a ProductIndex on higher-level Device Elements that don't otherwise log data