### PR TITLE
Single boom/bin and product allocations

### DIFF
--- a/ISOv4Plugin/Mappers/TimeLogMapper.cs
+++ b/ISOv4Plugin/Mappers/TimeLogMapper.cs
@@ -552,6 +552,12 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                 ISODeviceElement deviceElement = dvc.DeviceElements.FirstOrDefault(d => d.DeviceElementId == pan.DeviceElementIdRef);
                 if (deviceElement != null) //Filter PANs by this DVC
                 {
+                    // If device element was merged with another one, use it instead
+                    var mergedElement = TaskDataMapper.DeviceElementHierarchies.GetMatchingElement(deviceElement.DeviceElementId, true);
+                    if (mergedElement != null)
+                    {
+                        deviceElement = mergedElement.DeviceElement;
+                    }
                     AddProductAllocationsForDeviceElement(reportedPANs, pan, deviceElement, $"{GetHierarchyPosition(deviceElement)}_{panIndex}");
                 }
                 panIndex++;
@@ -587,13 +593,17 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
         private int GetLowestProductAllocationLevel(DeviceHierarchyElement isoDeviceElementHierarchy, Dictionary<string, List<ISOProductAllocation>> isoProductAllocations)
         {
             int level = -1;
-            // If device element has direct product allocations, use its Depth.
+            // If device element or any merged device elements have direct product allocations, use its Depth.
             if (isoDeviceElementHierarchy != null &&
-                isoProductAllocations.TryGetValue(isoDeviceElementHierarchy.DeviceElement.DeviceElementId, out List<ISOProductAllocation> productAllocations) &&
-                productAllocations.Any(x => x.DeviceElementIdRef == isoDeviceElementHierarchy.DeviceElement.DeviceElementId))
+                isoProductAllocations.TryGetValue(isoDeviceElementHierarchy.DeviceElement.DeviceElementId, out List<ISOProductAllocation> productAllocations))
             {
-                level = isoDeviceElementHierarchy.Depth;
-            }
+                var deviceElementIds = new List<string> { isoDeviceElementHierarchy.DeviceElement.DeviceElementId };
+                deviceElementIds.AddRange(isoDeviceElementHierarchy.MergedElements.Select(x => x.DeviceElementId));
+                if (productAllocations.Any(x => deviceElementIds.Contains(x.DeviceElementIdRef)))
+                {
+                    level = isoDeviceElementHierarchy.Depth;
+                }
+            }           
 
             // Get max level from children elements
             int? maxChildLevel = isoDeviceElementHierarchy?.Children?.Max(x => GetLowestProductAllocationLevel(x, isoProductAllocations));

--- a/ISOv4Plugin/ObjectModel/DeviceElementHierarchy.cs
+++ b/ISOv4Plugin/ObjectModel/DeviceElementHierarchy.cs
@@ -47,11 +47,11 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ObjectModel
 
         public Dictionary<string, DeviceHierarchyElement> Items { get; set; }
 
-        public DeviceHierarchyElement GetMatchingElement(string isoDeviceElementId)
+        public DeviceHierarchyElement GetMatchingElement(string isoDeviceElementId, bool includeMergedElements = false)
         {
             foreach (DeviceHierarchyElement hierarchy in this.Items.Values)
             {
-                DeviceHierarchyElement foundModel = hierarchy.FromDeviceElementID(isoDeviceElementId);
+                DeviceHierarchyElement foundModel = hierarchy.FromDeviceElementID(isoDeviceElementId, includeMergedElements);
                 if (foundModel != null)
                 {
                     return foundModel;
@@ -358,9 +358,9 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ObjectModel
         public DeviceHierarchyElement Parent { get; set; }
 
 
-        public DeviceHierarchyElement FromDeviceElementID(string deviceElementID)
+        public DeviceHierarchyElement FromDeviceElementID(string deviceElementID, bool includeMergedElements = false)
         {
-            if (DeviceElement?.DeviceElementId == deviceElementID)
+            if (DeviceElement?.DeviceElementId == deviceElementID || (includeMergedElements && MergedElements.Any(x => x.DeviceElementId == deviceElementID)))
             {
                 return this;
             }
@@ -368,7 +368,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ObjectModel
             {
                 foreach (DeviceHierarchyElement child in Children)
                 {
-                    DeviceHierarchyElement childModel = child.FromDeviceElementID(deviceElementID);
+                    DeviceHierarchyElement childModel = child.FromDeviceElementID(deviceElementID, includeMergedElements);
                     if (childModel != null)
                     {
                         return childModel;


### PR DESCRIPTION
ISO Plugin has a special logic to detect a boom with a single bin. In such situations bin's children/sensors are moved to a new parent - boom. But the same logic is not applied to product allocations that still referencing bin element. As a result, product allocations can not be processed and missing from OperationData.

This PR addresses this limitation and adds logic to correctly handle this situation and attach product allocations to boom.