### PR TITLE
Adding FieldBoundary description from polygon designator if present

### DIFF
--- a/ISOv4Plugin/Mappers/PartfieldMapper.cs
+++ b/ISOv4Plugin/Mappers/PartfieldMapper.cs
@@ -257,6 +257,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                 fieldBoundary = new FieldBoundary
                 {
                     FieldId = field.Id.ReferenceId,
+                    Description = isoPartfield.Polygons.Select(item => item.PolygonDesignator).FirstOrDefault(attr => attr != null),
                     SpatialData = boundary,
                 };
 


### PR DESCRIPTION
When importing isoxml task data the PartField polygon for the boundary is missing the designator in the ADM model. This used the Description attribute to hold the designator from isoxml. Some vendors use the description during their import and this expect it to be set.