### PR TITLE
Look for valid GPS date/time when determining TaskDataMapper.GPSToLocalDelta

### DIFF
--- a/ISOv4Plugin/Mappers/TimeLogMapper.cs
+++ b/ISOv4Plugin/Mappers/TimeLogMapper.cs
@@ -324,8 +324,9 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                     //Set a UTC "delta" from the first record where possible.  We set only one per data import.
                     if (!TaskDataMapper.GPSToLocalDelta.HasValue)
                     {
-                        var firstRecord = isoRecords.FirstOrDefault();
-                        if (firstRecord != null && firstRecord.GpsUtcDateTime.HasValue)
+                        //Find the first record with a valid GPS time and date. A GpsUtcDate of 0x0000 or 0xFFFF indicates an invalid date.
+                        var firstRecord = isoRecords.FirstOrDefault(r => r.GpsUtcDateTime.HasValue && r.GpsUtcDate != ushort.MaxValue && r.GpsUtcDate != 0);
+                        if (firstRecord != null)
                         {
                             //Local - UTC = Delta.  This value will be rough based on the accuracy of the clock settings but will expose the ability to derive the UTC times from the exported local times.
                             TaskDataMapper.GPSToLocalDelta = (firstRecord.TimeStart - firstRecord.GpsUtcDateTime.Value).TotalHours;


### PR DESCRIPTION
## Summary

Handle an edge case where spatial records with bad GPS data are used to find the UTC offset for unspecified date/time values.

## Background

Encountered input data where the `vrProductIndex` meter values were incorrect. Traced the problem to SpatialRecordMapper.cs around line 159, then into the `GovernsTimestamp` method, then into the `ToUtc` method. The spatial record timestamp values'  `Kind` is `DateTimeKind.Unspecified`, so `ToUtc()` uses `TaskDataMapper.GPSToLocalDelta` to adjust the value. However, after adjustment the timestamp values were nonsensical; e.g. `{8/4/2159 9:00:53 PM}`.

`TaskDataMapper.GPSToLocalDelta` is set at TimeLogMapper.cs, line 331, by getting the first spatial record and comparing its `TimeStart` value to the `GpsUtcDateTime` value. For the data in question, the first 76 spatial records had bad GPS data (latitude and longitude values were both -1E-07 in addition to the bad GPS time values). Using a bad time value to compute `GPSToLocalDelta` led to bad adjusted UTC date/times, which led to incorrect time comparisons with the product allocations.

The fix finds the first spatial record _with valid GPS data_ when finding the `GPSToLocalDelta`, rather than the first spatial record overall.