### PR TITLE
Fix NullReferenceException in WorkingDataMapper.UpdateCondensedWorkingData

### DIFF
--- a/ISOv4Plugin/Mappers/LoggedDataMappers/Import/WorkingDataMapper.cs
+++ b/ISOv4Plugin/Mappers/LoggedDataMappers/Import/WorkingDataMapper.cs
@@ -217,6 +217,12 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
         private void UpdateCondensedWorkingDatas(List<ISOEnumeratedMeter> condensedWorkingDatas, ISODataLogValue dlv, DeviceElementUse deviceElementUse, List<DeviceElementUse> pendingDeviceElementUses, DeviceHierarchyElement isoDeviceElementHierarchy)
         {
             ISODeviceElement isoDeviceElement = TaskDataMapper.DeviceElementHierarchies.GetISODeviceElementFromID(dlv.DeviceElementIdRef);
+            if (isoDeviceElement == null)
+            {
+                // If no device element found for the log value, nothing more to do here
+                return;
+            }
+
             List<ISODeviceElement> isoSectionElements = isoDeviceElement.ChildDeviceElements.Where(d => d.DeviceElementType == ISOEnumerations.ISODeviceElementType.Section).ToList();
             foreach (var subElement in isoDeviceElement.ChildDeviceElements)
             {


### PR DESCRIPTION
Seeing frequent NullReferenceExceptions thrown from `WorkingDataMapper.UpdateCondensedWorkingData` from CNH application data, specifically with this stack trace:
```
{System.NullReferenceException: Object reference not set to an instance of an object.
   at AgGateway.ADAPT.ISOv4Plugin.Mappers.WorkingDataMapper.UpdateCondensedWorkingDatas(List`1 condensedWorkingDatas, ISODataLogValue dlv, DeviceElementUse deviceElementUse, List`1 pendingDeviceElementUses, DeviceHierarchyElement isoDeviceElementHierarchy)
   at AgGateway.ADAPT.ISOv4Plugin.Mappers.WorkingDataMapper.Map(ISODataLogValue dlv, IEnumerable`1 isoSpatialRows, DeviceElementUse deviceElementUse, Byte order, List`1 pendingDeviceElementUses, DeviceHierarchyElement isoDeviceElementHierarchy)
   at AgGateway.ADAPT.ISOv4Plugin.Mappers.WorkingDataMapper.Map(ISOTime time, IEnumerable`1 isoSpatialRows, DeviceElementUse deviceElementUse, DeviceHierarchyElement isoDeviceElementHierarchy, List`1 pendingDeviceElementUses, Dictionary`2 isoProductAllocations)
   at AgGateway.ADAPT.ISOv4Plugin.Mappers.SectionMapper.Map(ISOTime time, IEnumerable`1 isoRecords, Int32 operationDataId, IEnumerable`1 isoDeviceElementIDs, Dictionary`2 isoProductAllocations)
   at AgGateway.ADAPT.ISOv4Plugin.Mappers.TimeLogMapper.ImportTimeLog(ISOTask loggedTask, ISOTimeLog isoTimeLog, Nullable`1 prescriptionID)
   at AgGateway.ADAPT.ISOv4Plugin.Mappers.TimeLogMapper.ImportTimeLogs(ISOTask loggedTask, IEnumerable`1 timeLogs, Nullable`1 prescriptionID)
   at AgGateway.ADAPT.ISOv4Plugin.Mappers.Factories.TimeLogMapperFactory.ImportTimeLogs(ISOTask loggedTask, Nullable`1 prescriptionID)
   at AgGateway.ADAPT.ISOv4Plugin.Mappers.TaskMapper.ImportLoggedData(ISOTask isoLoggedTask)
   at AgGateway.ADAPT.ISOv4Plugin.Mappers.TaskMapper.ImportLoggedDatas(IEnumerable`1 isoLoggedTasks)
   at AgGateway.ADAPT.ISOv4Plugin.Mappers.TaskDataMapper.Import(ISO11783_TaskData taskData)
   at AgGateway.ADAPT.ISOv4Plugin.Plugin.Import(String dataPath, Properties properties)
```

Add a null check if `isoDeviceElement` is not found in the element cache.