### PR TITLE
Address missed changes and crash in Visualizer

### DIFF
--- a/ISOv4Plugin/Mappers/DeviceMapper.cs
+++ b/ISOv4Plugin/Mappers/DeviceMapper.cs
@@ -33,13 +33,10 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
     public class DeviceMapper : BaseMapper, IDeviceMapper
     {
         DeviceElementMapper _deviceElementMapper;
-        private readonly IManufacturer _manufacturer;
 
         public DeviceMapper(TaskDataMapper taskDataMapper) : base(taskDataMapper, "DVC")
         {
             _deviceElementMapper = new DeviceElementMapper(taskDataMapper);
-
-            _manufacturer = ManufacturerFactory.GetManufacturer(taskDataMapper);
         }
 
         #region Export

--- a/ISOv4Plugin/Mappers/TaskDataMapper.cs
+++ b/ISOv4Plugin/Mappers/TaskDataMapper.cs
@@ -501,8 +501,8 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                 }
             }
 
-                var manufacturer = ManufacturerFactory.GetManufacturer(this);
-                manufacturer?.PostProcessModel(AdaptDataModel, DeviceElementHierarchies);
+            var manufacturer = ManufacturerFactory.GetManufacturer(this);
+            manufacturer?.PostProcessModel(AdaptDataModel, DeviceElementHierarchies);
 
             return AdaptDataModel;
         }

--- a/ISOv4Plugin/ObjectModel/DeviceElementHierarchy.cs
+++ b/ISOv4Plugin/ObjectModel/DeviceElementHierarchy.cs
@@ -21,8 +21,6 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ObjectModel
 {
     public class DeviceElementHierarchies
     {
-        private readonly IManufacturer _manufacturer;
-
         public DeviceElementHierarchies(IEnumerable<ISODevice> devices,
                                         RepresentationMapper representationMapper,
                                         bool mergeBins,
@@ -35,6 +33,8 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ObjectModel
             //Track any device element geometries not logged as a DPT
             Dictionary<string, List<string>> missingGeometryDefinitions = new Dictionary<string, List<string>>();
 
+            var manufacturer = ManufacturerFactory.GetManufacturer(taskDataMapper);
+
             foreach (ISODevice device in devices)
             {
                 ISODeviceElement rootDeviceElement = device.DeviceElements.SingleOrDefault(det => det.DeviceElementType == ISODeviceElementType.Device);
@@ -44,7 +44,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ObjectModel
                     hierarchyElement.HandleBinDeviceElements();
                     Items.Add(device.DeviceId, hierarchyElement);
 
-                    _manufacturer?.ProcessDeviceElementHierarchy(hierarchyElement, missingGeometryDefinitions);
+                    manufacturer?.ProcessDeviceElementHierarchy(hierarchyElement, missingGeometryDefinitions);
                 }
             }
 

--- a/ISOv4Plugin/ObjectModel/ISOOperationData.cs
+++ b/ISOv4Plugin/ObjectModel/ISOOperationData.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using AgGateway.ADAPT.ApplicationDataModel.Equipment;
 using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
@@ -6,11 +7,57 @@ using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
 
 namespace AgGateway.ADAPT.ISOv4Plugin.ObjectModel
 {
-    internal class ISOOperationData : OperationData
+    internal class ISOOperationData : OperationData, IConvertible
     {
         /// <summary>
         /// An internal list of DeviceElementUses that are may be updated during import; not exposed on the public interface.
         /// </summary>
         internal List<DeviceElementUse> DeviceElementUses { get; set; } = new List<DeviceElementUse>();
+
+        #region IConvertible impelementation
+        public TypeCode GetTypeCode()
+        {
+            return TypeCode.Object;
+        }
+
+        public bool ToBoolean(IFormatProvider provider) => throw new NotImplementedException();
+
+        public byte ToByte(IFormatProvider provider) => throw new NotImplementedException();
+
+        public char ToChar(IFormatProvider provider) => throw new NotImplementedException();
+
+        public DateTime ToDateTime(IFormatProvider provider) => throw new NotImplementedException();
+
+        public decimal ToDecimal(IFormatProvider provider) => throw new NotImplementedException();
+
+        public double ToDouble(IFormatProvider provider) => throw new NotImplementedException();
+
+        public short ToInt16(IFormatProvider provider) => throw new NotImplementedException();
+
+        public int ToInt32(IFormatProvider provider) => throw new NotImplementedException();
+
+        public long ToInt64(IFormatProvider provider) => throw new NotImplementedException();
+
+        public sbyte ToSByte(IFormatProvider provider) => throw new NotImplementedException();
+
+        public float ToSingle(IFormatProvider provider) => throw new NotImplementedException();
+
+        public string ToString(IFormatProvider provider) => throw new NotImplementedException();
+
+        public object ToType(Type conversionType, IFormatProvider provider)
+        {
+            if (conversionType == typeof(ISOOperationData) || conversionType == typeof(OperationData))
+            {
+                return this;
+            }
+            throw new NotImplementedException();
+        }
+
+        public ushort ToUInt16(IFormatProvider provider) => throw new NotImplementedException();
+
+        public uint ToUInt32(IFormatProvider provider) => throw new NotImplementedException();
+
+        public ulong ToUInt64(IFormatProvider provider) => throw new NotImplementedException();
+        #endregion
     }
 }


### PR DESCRIPTION
This PR resolves two issues from the latest set of changes to better support CNH data sets:
- missed handling of new sensor
- crash inside Visualizer due to use of derived class for OperationData