### PR TITLE
Handle OverflowException and NullReferenceException

### DIFF
--- a/ISOv4Plugin/Mappers/GuidancePatternMapper.cs
+++ b/ISOv4Plugin/Mappers/GuidancePatternMapper.cs
@@ -13,7 +13,6 @@ using AgGateway.ADAPT.ISOv4Plugin.ExtensionMethods;
 using AgGateway.ADAPT.ISOv4Plugin.ISOEnumerations;
 using AgGateway.ADAPT.ISOv4Plugin.ISOModels;
 using AgGateway.ADAPT.Representation.UnitSystem;
-using AgGateway.ADAPT.ISOv4Plugin.ExtensionMethods;
 
 namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
 {

--- a/ISOv4Plugin/ObjectModel/DeviceElementHierarchy.cs
+++ b/ISOv4Plugin/ObjectModel/DeviceElementHierarchy.cs
@@ -11,16 +11,17 @@ using AgGateway.ADAPT.ISOv4Plugin.Representation;
 using System.Collections.Generic;
 using System.Linq;
 using System.IO;
-using System.Runtime.InteropServices;
-using System.Security.Cryptography.X509Certificates;
 using AgGateway.ADAPT.ApplicationDataModel.Equipment;
 using AgGateway.ADAPT.ISOv4Plugin.Mappers.Manufacturers;
 using AgGateway.ADAPT.ISOv4Plugin.Mappers;
+using AgGateway.ADAPT.ApplicationDataModel.ADM;
 
 namespace AgGateway.ADAPT.ISOv4Plugin.ObjectModel
 {
     public class DeviceElementHierarchies
     {
+        private readonly List<IError> _errors;
+
         public DeviceElementHierarchies(IEnumerable<ISODevice> devices,
                                         RepresentationMapper representationMapper,
                                         bool mergeBins,
@@ -29,6 +30,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ObjectModel
                                         TaskDataMapper taskDataMapper)
         {
             Items = new Dictionary<string, DeviceHierarchyElement>();
+            _errors = taskDataMapper.Errors;
 
             //Track any device element geometries not logged as a DPT
             Dictionary<string, List<string>> missingGeometryDefinitions = new Dictionary<string, List<string>>();
@@ -156,7 +158,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ObjectModel
                         string binaryPath = taskDataPath.GetDirectoryFiles(binaryName, SearchOption.TopDirectoryOnly).FirstOrDefault();
                         if (binaryPath != null)
                         {
-                            Dictionary<byte, int> timelogValues = Mappers.TimeLogMapper.ReadImplementGeometryValues(dlvsToRead.Select(d => d.Index), time, binaryPath, version);
+                            Dictionary<byte, int> timelogValues = Mappers.TimeLogMapper.ReadImplementGeometryValues(dlvsToRead.Select(d => d.Index), time, binaryPath, version, _errors);
 
                             foreach (byte reportedDLVIndex in timelogValues.Keys)
                             {


### PR DESCRIPTION
Two separate fixes for edge cases found from recent CNH data.

- Catch OverflowException in BinaryReader.ReadImplementGeometryValues and add the error to plugin errors collection
- Include the errors collection as an argument in several methods to allow the errors to be added to the `IPlugin.Errors` collection and available to the caller
- Handle a null `TaskMapper.DeviceElementHierarchies` value in `TimeLogMapper.ImportTimeLog()`
- Remove duplicate `using` statement in GuidancePatternMapper that was causing a warning