### PR TITLE
Handle exceptions thrown from GuidancePatternMapper.ImportGuidancePattern()

### DIFF
--- a/ISOv4Plugin/Mappers/GuidancePatternMapper.cs
+++ b/ISOv4Plugin/Mappers/GuidancePatternMapper.cs
@@ -214,18 +214,10 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             List<GuidancePattern> adaptGuidancePatterns = new List<GuidancePattern>();
             foreach (ISOGuidancePattern isoGuidancePattern in isoGuidancePatterns)
             {
-                try
+                GuidancePattern adaptGuidancePattern = ImportGuidancePattern(isoGuidancePattern);
+                if (adaptGuidancePattern != null)
                 {
-                    GuidancePattern adaptGuidancePattern = ImportGuidancePattern(isoGuidancePattern);
                     adaptGuidancePatterns.Add(adaptGuidancePattern);
-                }
-                catch (ArgumentOutOfRangeException ex)
-                {
-                    TaskDataMapper.AddError($"Guidance pattern {isoGuidancePattern.GuidancePatternDesignator} is invalid.  Skipping.", ex.Message, null, ex.StackTrace);
-                }
-                catch (InvalidOperationException ex)
-                {
-                    TaskDataMapper.AddError($"Guidance pattern {isoGuidancePattern.GuidancePatternDesignator} is invalid.  Skipping.", ex.Message, null, ex.StackTrace);
                 }
             }
 
@@ -247,7 +239,13 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             GuidancePattern pattern = null;
             LineStringMapper lineStringMapper = new LineStringMapper(TaskDataMapper);
             PointMapper pointMapper = new PointMapper(TaskDataMapper);
-            var isoLineString = isoGuidancePattern.LineString ?? new ISOLineString();
+            ISOLineString isoLineString = isoGuidancePattern.LineString;
+            if (isoLineString == null || isoLineString.Points.Count == 0)
+            {
+                TaskDataMapper.AddError($"Guidance pattern {isoGuidancePattern.GuidancePatternDesignator} is invalid. Skipping.");
+                return null;
+            }
+
             switch (isoGuidancePattern.GuidancePatternType)
             {
                 case ISOGuidancePatternType.AB:

--- a/ISOv4Plugin/Mappers/GuidancePatternMapper.cs
+++ b/ISOv4Plugin/Mappers/GuidancePatternMapper.cs
@@ -240,7 +240,7 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             LineStringMapper lineStringMapper = new LineStringMapper(TaskDataMapper);
             PointMapper pointMapper = new PointMapper(TaskDataMapper);
             ISOLineString isoLineString = isoGuidancePattern.LineString;
-            if (isoLineString == null || isoLineString.Points.Count == 0)
+            if ((isoLineString?.Points?.Count ?? 0) == 0)
             {
                 TaskDataMapper.AddError($"Guidance pattern {isoGuidancePattern.GuidancePatternDesignator} is invalid. Skipping.");
                 return null;

--- a/ISOv4Plugin/Mappers/GuidancePatternMapper.cs
+++ b/ISOv4Plugin/Mappers/GuidancePatternMapper.cs
@@ -214,8 +214,19 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
             List<GuidancePattern> adaptGuidancePatterns = new List<GuidancePattern>();
             foreach (ISOGuidancePattern isoGuidancePattern in isoGuidancePatterns)
             {
-                GuidancePattern adaptGuidancePattern = ImportGuidancePattern(isoGuidancePattern);
-                adaptGuidancePatterns.Add(adaptGuidancePattern);
+                try
+                {
+                    GuidancePattern adaptGuidancePattern = ImportGuidancePattern(isoGuidancePattern);
+                    adaptGuidancePatterns.Add(adaptGuidancePattern);
+                }
+                catch (ArgumentOutOfRangeException ex)
+                {
+                    TaskDataMapper.AddError($"Guidance pattern {isoGuidancePattern.GuidancePatternDesignator} is invalid.  Skipping.", ex.Message, null, ex.StackTrace);
+                }
+                catch (InvalidOperationException ex)
+                {
+                    TaskDataMapper.AddError($"Guidance pattern {isoGuidancePattern.GuidancePatternDesignator} is invalid.  Skipping.", ex.Message, null, ex.StackTrace);
+                }
             }
 
             //Add the patterns to the Catalog


### PR DESCRIPTION
ISO data submitted to us for import contained an ABLine-type guidance pattern without any points, i.e.
```
    <GGP A="GGP-1" B="xxxx">
      <GPN A="GPN-1" B="xxxx" C="1" E="1" F="1" />
    </GGP>
```

Rather than throwing a `System.InvalidOperationException`, this change allows the import to continue, adding information about the exception to the `plugin.Errors` collection. It also catches `ArgumentOutOfRangeException`, which would happen indexing LineString points for Pivot-type guidance patterns in the same method.