### PR TITLE
Handle null representation code when examining WorkingDatas

### DIFF
--- a/ISOv4Plugin/ExtensionMethods/ExtensionMethods.cs
+++ b/ISOv4Plugin/ExtensionMethods/ExtensionMethods.cs
@@ -95,6 +95,13 @@ namespace AgGateway.ADAPT.ISOv4Plugin.ExtensionMethods
             return true;
         }
 
+        /// <summary>
+        /// Matches NumericRepresentation by code, accounting for null representation code
+        /// </summary>
+        public static bool ContainsCode(this ApplicationDataModel.Representations.Representation representation, string code)
+        {
+            return representation?.Code != null && representation.Code.Contains(code);
+        }
 
         /// <summary>
         /// Looks up unit, converts and loads representation

--- a/ISOv4Plugin/Mappers/TimeLogMapper.cs
+++ b/ISOv4Plugin/Mappers/TimeLogMapper.cs
@@ -431,17 +431,17 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
         private OperationTypeEnum? GetOperationTypeFromWorkingDatas(List<WorkingData> workingDatas)
         {
             //Harvest/ForageHarvest omitted intentionally to be determined from machine type vs. working data
-            if (workingDatas.Any(w => w.Representation.Code.Contains("Seed")))
+            if (workingDatas.Any(w => w.Representation.ContainsCode("Seed")))
             {
                 return OperationTypeEnum.SowingAndPlanting;
             }
-            else if (workingDatas.Any(w => w.Representation.Code.Contains("Tillage")))
+            else if (workingDatas.Any(w => w.Representation.ContainsCode("Tillage")))
             {
                 return OperationTypeEnum.Tillage;
             }
-            if (workingDatas.Any(w => w.Representation.Code.Contains("AppRate")))
+            if (workingDatas.Any(w => w.Representation.ContainsCode("AppRate")))
             {
-                return OperationTypeEnum.Unknown; //We can't differentiate CropProtection from Fertilizing, but prefer unkonwn to letting implement type set to SowingAndPlanting
+                return OperationTypeEnum.Unknown; //We can't differentiate CropProtection from Fertilizing, but prefer unknown to letting implement type set to SowingAndPlanting
             }
             return null;
         }


### PR DESCRIPTION
We encountered another `NullReferenceException` for real-world data sent to us. This one had a `WorkingData` with a null `Representation.Code` value. Created an extension method to do the `string.Contains` operation only if the representation code is non-null.