### PR TITLE
Two fixes for reading CNH Pro1200 Harvest data

### DIFF
--- a/ISOv4Plugin/Mappers/TimeLogMapper.cs
+++ b/ISOv4Plugin/Mappers/TimeLogMapper.cs
@@ -684,9 +684,6 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
 
             switch (productCategories.FirstOrDefault())
             {
-                case CategoryEnum.Variety:
-                    return OperationTypeEnum.SowingAndPlanting;
-
                 case CategoryEnum.Fertilizer:
                 case CategoryEnum.NitrogenStabilizer:
                 case CategoryEnum.Manure:
@@ -724,7 +721,9 @@ namespace AgGateway.ADAPT.ISOv4Plugin.Mappers
                 }
             }
 
-            DeviceOperationType deviceType = representedTypes.FirstOrDefault(t => t.ClientNAMEMachineType >= 2 && t.ClientNAMEMachineType <= 11);
+            DeviceOperationType deviceType = representedTypes.FirstOrDefault(t => t.ClientNAMEMachineType >= 2 && t.ClientNAMEMachineType <= 11 &&
+                t.OperationType != OperationTypeEnum.Unknown);
+
             if (deviceType != null)
             {
                 //2-11 represent known types of operations


### PR DESCRIPTION
We have harvest data from a CNH Pro1200 display that is coming in as SowingAndPlanting with 5.6.2.  Additionally, we observed that sometimes Unknown is being returned from TimeLogMapper.GetOperationTypeFromLoggingDevices when there was a more meaningful operation available in the list.  This PR addresses those two issues with the following changes:

1. Stop forcing CategoryEnum.Variety to OperationTypeEnum.SowingAndPlanting (could be Harvesting)
2. In GetOperationTypeFromLoggingDevices, prefer a non-Unknown operation type when there are multiple options